### PR TITLE
Move start-up logic into a view

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ void main() async {
   setupLocator();
   WidgetsFlutterBinding.ensureInitialized();
 
-  await locator.allReady();
+  locator.allReadySync();
 
   runApp(const KanaToKanjiApp());
 }

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -4,8 +4,10 @@ import 'package:kana_to_kanji/src/core/models/group.dart';
 import 'package:kana_to_kanji/src/quiz/conclusion/quiz_conclusion_view.dart';
 import 'package:kana_to_kanji/src/quiz/models/question.dart';
 import 'package:kana_to_kanji/src/quiz/quiz_view.dart';
+import 'package:kana_to_kanji/src/splash/splash_view.dart';
 
-final router = GoRouter(initialLocation: PrepareQuizView.routeName, routes: [
+final router = GoRouter(initialLocation: SplashView.routeName, routes: [
+  GoRoute(path: SplashView.routeName, builder: (_, __) => const SplashView()),
   GoRoute(
       path: PrepareQuizView.routeName,
       builder: (_, __) => const PrepareQuizView(),

--- a/lib/src/splash/splash_view.dart
+++ b/lib/src/splash/splash_view.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kana_to_kanji/src/core/widgets/app_scaffold.dart';
+import 'package:kana_to_kanji/src/splash/splash_view_model.dart';
+import 'package:rive/rive.dart';
+import 'package:stacked/stacked.dart';
+
+class SplashView extends StatelessWidget {
+  static const routeName = "/splash";
+
+  const SplashView({super.key});
+
+  static const TextStyle _style = TextStyle(
+      fontFamily: 'MPlusRounded1c',
+      fontWeight: FontWeight.w400,
+      fontSize: 60.0);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context);
+
+    return ViewModelBuilder<SplashViewModel>.nonReactive(
+      viewModelBuilder: () => SplashViewModel(GoRouter.of(context)),
+      builder: (context, _, __) => AppScaffold(
+          body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text.rich(
+                TextSpan(text: l10n.app_title_kana, children: [
+                  TextSpan(
+                      text: l10n.app_title_to,
+                      style: const TextStyle(color: Color(0xffFF862F))),
+                  TextSpan(text: l10n.app_title_kanji)
+                ]),
+                style: _style),
+            const Padding(
+              padding: EdgeInsets.only(top: 40.0),
+              child: SizedBox(
+                  width: 300,
+                  height: 300,
+                  child: RiveAnimation.asset(
+                    "assets/animations/kitsune_hot_cup_of_tea.riv",
+                    artboard: "main",
+                  )),
+            ),
+          ],
+        ),
+      )),
+    );
+  }
+}

--- a/lib/src/splash/splash_view_model.dart
+++ b/lib/src/splash/splash_view_model.dart
@@ -1,0 +1,19 @@
+import 'package:go_router/go_router.dart';
+import 'package:kana_to_kanji/src/locator.dart';
+import 'package:kana_to_kanji/src/quiz/prepare/prepare_quiz_view.dart';
+import 'package:stacked/stacked.dart';
+
+class SplashViewModel extends FutureViewModel {
+  final GoRouter goRouter;
+
+  SplashViewModel(this.goRouter);
+
+  /// Here we check that everything is ready before moving to the main screen
+  @override
+  Future futureToRun() async {
+    await locator.allReady();
+
+    // Move to main screen
+    goRouter.replace(PrepareQuizView.routeName);
+  }
+}

--- a/lib/src/splash/splash_view_model.dart
+++ b/lib/src/splash/splash_view_model.dart
@@ -13,7 +13,8 @@ class SplashViewModel extends FutureViewModel {
   Future futureToRun() async {
     await Future.wait([
       locator.allReady(),
-      Future.delayed(const Duration(seconds: 1)) // Wait 1s to have the time to load the animation
+      Future.delayed(const Duration(
+          seconds: 1)) // Wait 1s to have the time to load the animation
     ]);
 
     // Move to main screen

--- a/lib/src/splash/splash_view_model.dart
+++ b/lib/src/splash/splash_view_model.dart
@@ -11,7 +11,10 @@ class SplashViewModel extends FutureViewModel {
   /// Here we check that everything is ready before moving to the main screen
   @override
   Future futureToRun() async {
-    await locator.allReady();
+    await Future.wait([
+      locator.allReady(),
+      Future.delayed(const Duration(seconds: 1)) // Wait 1s to have the time to load the animation
+    ]);
 
     // Move to main screen
     goRouter.replace(PrepareQuizView.routeName);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.1.6+1
+version: 0.2.0+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'


### PR DESCRIPTION
## 📖 Description
<!--- Describe your changes in detail -->

Move the start-up logic to the new `SplashView` so we have a nice animation while we are loading everything we need

### ⁉️ Related Issues
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--- Please link the issue here: (use keyword `closes: #12345`) -->

closes #25 

<!--- If it's a visual change, please provide a screenshot/video of the changes -->
### 🖼️ Screenshots:
<!--- Use the spoiler system for your screenshots/videos -->

<details>
    <summary>Demo</summary> 
   
https://github.com/RoadTripMoustache/kana_to_kanji/assets/22211097/35f17b64-e67c-4aa9-85b0-c48d6136ba9a

</details>

### 🧪 How to test the change?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your unit test, and the manual tests you did -->
<!--- see how your change affects other areas of the code, etc. -->

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.