### PR TITLE
Store the theme mode and link 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kana_to_kanji/src/app.dart';
+import 'package:kana_to_kanji/src/core/repositories/settings_repository.dart';
 import 'package:kana_to_kanji/src/locator.dart';
 
 void main() async {
@@ -8,5 +9,8 @@ void main() async {
 
   locator.allReadySync();
 
-  runApp(const KanaToKanjiApp());
+  // Load the user settings. Need to be run before the runApp for the theme mode.
+  await locator<SettingsRepository>().loadSettings();
+
+  runApp(KanaToKanjiApp());
 }

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,30 +1,38 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:kana_to_kanji/src/core/constants/app_theme.dart';
+import 'package:kana_to_kanji/src/core/repositories/settings_repository.dart';
+import 'package:kana_to_kanji/src/locator.dart';
 import 'package:kana_to_kanji/src/router.dart';
 
 class KanaToKanjiApp extends StatelessWidget {
-  const KanaToKanjiApp({
+  final SettingsRepository _settingsRepository = locator<SettingsRepository>();
+
+  KanaToKanjiApp({
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-        restorationScopeId: 'app',
+    return AnimatedBuilder(
+        animation: _settingsRepository,
+        builder: (BuildContext context, _) {
+          return MaterialApp.router(
+              restorationScopeId: 'app',
 
-        // Localizations
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        onGenerateTitle: (BuildContext context) =>
-            AppLocalizations.of(context).app_title,
+              // Localizations
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              onGenerateTitle: (BuildContext context) =>
+                  AppLocalizations.of(context).app_title,
 
-        // Theme
-        theme: AppTheme.light(),
-        darkTheme: AppTheme.dark(),
-        themeMode: ThemeMode.system,
+              // Theme
+              theme: AppTheme.light(),
+              darkTheme: AppTheme.dark(),
+              themeMode: _settingsRepository.themeMode,
 
-        // Router
-        routerConfig: router);
+              // Router
+              routerConfig: router);
+        });
   }
 }

--- a/lib/src/core/constants/preference_flags.dart
+++ b/lib/src/core/constants/preference_flags.dart
@@ -1,0 +1,4 @@
+
+enum PreferenceFlags {
+  themeMode
+}

--- a/lib/src/core/repositories/settings_repository.dart
+++ b/lib/src/core/repositories/settings_repository.dart
@@ -1,5 +1,38 @@
-class SettingsRepository {
+import 'package:flutter/material.dart';
+import 'package:kana_to_kanji/src/core/constants/preference_flags.dart';
+import 'package:kana_to_kanji/src/core/services/preferences_service.dart';
+import 'package:kana_to_kanji/src/locator.dart';
+
+class SettingsRepository with ChangeNotifier {
+  final PreferencesService _preferencesService = locator<PreferencesService>();
+
+  late ThemeMode _themeMode;
+
+  ThemeMode get themeMode => _themeMode;
+
   int getMaximumAttemptsByQuestion() {
     return 3;
+  }
+
+  /// Load the user's settings.
+  Future<void> loadSettings() async {
+    String? modeValue =
+        await _preferencesService.getString(PreferenceFlags.themeMode);
+
+    _themeMode = ThemeMode.values.firstWhere((e) => e.toString() == modeValue,
+        orElse: () => ThemeMode.system);
+
+    notifyListeners();
+  }
+
+  /// Update and persist the ThemeMode based on the user's selection.
+  Future<void> updateThemeMode(ThemeMode? newThemeMode) async {
+    if (newThemeMode == null || newThemeMode == _themeMode) return;
+
+    _themeMode = newThemeMode;
+
+    notifyListeners();
+    await _preferencesService.setString(
+        PreferenceFlags.themeMode, newThemeMode.toString());
   }
 }

--- a/lib/src/core/services/preferences_service.dart
+++ b/lib/src/core/services/preferences_service.dart
@@ -1,0 +1,65 @@
+import 'package:kana_to_kanji/src/core/constants/preference_flags.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PreferencesService {
+  Future<bool> setBool(PreferenceFlags flag, bool value) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    return prefs.setBool(flag.toString(), value);
+  }
+
+  Future<bool> setString(PreferenceFlags flag, String value) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    return prefs.setString(flag.toString(), value);
+  }
+
+  Future<void> clear() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+  }
+
+  Future<Object?> get(PreferenceFlags flag) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.get(flag.toString());
+  }
+
+  Future<bool> removePreferenceFlags(PreferenceFlags flag) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.remove(flag.toString());
+  }
+
+  Future<bool> setInt(PreferenceFlags flag, int value) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    return prefs.setInt(flag.toString(), value);
+  }
+
+  Future<bool> setDateTime(PreferenceFlags flag, DateTime value) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.setString(flag.toString(), value.toIso8601String());
+  }
+
+  Future<bool?> getBool(PreferenceFlags flag) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(flag.toString());
+  }
+
+  Future<int?> getInt(PreferenceFlags flag) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    return prefs.getInt(flag.toString());
+  }
+
+  Future<String?> getString(PreferenceFlags flag) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    return prefs.getString(flag.toString());
+  }
+
+  Future<DateTime?> getDateTime(PreferenceFlags flag) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    return DateTime.tryParse(prefs.getString(flag.toString()) ?? "");
+  }
+}

--- a/lib/src/locator.dart
+++ b/lib/src/locator.dart
@@ -23,7 +23,7 @@ void setupLocator() {
   locator.registerLazySingleton<PreferencesService>(() => PreferencesService());
   locator.registerLazySingleton<GroupsRepository>(() => GroupsRepository());
   locator.registerLazySingleton<KanaRepository>(() => KanaRepository());
-  locator.registerLazySingleton<SettingsRepository>(() => SettingsRepository());
+  locator.registerSingleton<SettingsRepository>(SettingsRepository());
   locator.registerSingletonAsync<InfoService>(() async {
     final instance = InfoService();
     await instance.initialize();

--- a/lib/src/locator.dart
+++ b/lib/src/locator.dart
@@ -6,6 +6,7 @@ import 'package:kana_to_kanji/src/core/models/kana.dart';
 import 'package:kana_to_kanji/src/core/repositories/groups_repository.dart';
 import 'package:kana_to_kanji/src/core/repositories/kana_repository.dart';
 import 'package:kana_to_kanji/src/core/services/info_service.dart';
+import 'package:kana_to_kanji/src/core/services/preferences_service.dart';
 import 'package:logger/logger.dart';
 
 final GetIt locator = GetIt.instance;
@@ -19,6 +20,7 @@ void setupLocator() {
 
     return instance;
   });
+  locator.registerLazySingleton<PreferencesService>(() => PreferencesService());
   locator.registerLazySingleton<GroupsRepository>(() => GroupsRepository());
   locator.registerLazySingleton<KanaRepository>(() => KanaRepository());
   locator.registerLazySingleton<SettingsRepository>(() => SettingsRepository());

--- a/lib/src/settings/settings_view_model.dart
+++ b/lib/src/settings/settings_view_model.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:kana_to_kanji/src/core/repositories/settings_repository.dart';
 import 'package:kana_to_kanji/src/core/services/info_service.dart';
 import 'package:kana_to_kanji/src/locator.dart';
 import 'package:stacked/stacked.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class SettingsViewModel extends BaseViewModel {
+  final SettingsRepository _repository = locator<SettingsRepository>();
   final InfoService _infoService = locator<InfoService>();
 
   final AppLocalizations l10n;
@@ -28,13 +30,13 @@ class SettingsViewModel extends BaseViewModel {
         },
       };
 
-  ThemeMode _themeMode = ThemeMode.system;
+  ThemeMode get _themeMode => _repository.themeMode;
 
   List<bool> get themeModeSelected =>
       themeModes.keys.map((e) => e == _themeMode).toList(growable: false);
 
   Future<void> setThemeMode(int index) async {
-    _themeMode = themeModes.keys.elementAt(index);
+    await _repository.updateThemeMode(themeModes.keys.elementAt(index));
     notifyListeners();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
@@ -477,6 +477,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -533,6 +565,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.6"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: b7f41bad7e521d205998772545de63ff4e6c97714775902c199353f8bf1511ac
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "7bf53a9f2d007329ee6f3df7268fd498f8373602f943c975598bbb34649b62a7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: c2eb5bf57a2fe9ad6988121609e47d3e07bb3bdca5b6f8444e4cf302428a128a
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: f763a101313bd3be87edffe0560037500967de9c394a714cd598d945517f694f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   shelf:
     dependency: transitive
     description:
@@ -730,6 +818,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.7"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   stacked: ^3.4.0
   rive: ^0.11.14
   package_info_plus: ^4.1.0
+  shared_preferences: ^2.2.1
 
 dev_dependencies:
   flutter_test:

--- a/test/src/core/repositories/settings_repository_test.dart
+++ b/test/src/core/repositories/settings_repository_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kana_to_kanji/src/core/constants/preference_flags.dart';
+import 'package:kana_to_kanji/src/core/repositories/settings_repository.dart';
+import 'package:kana_to_kanji/src/core/services/preferences_service.dart';
+import 'package:kana_to_kanji/src/locator.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../helpers.dart';
+@GenerateNiceMocks([MockSpec<PreferencesService>()])
+import 'settings_repository_test.mocks.dart';
+
+void main() {
+  group("SettingsRepository", () {
+    late SettingsRepository repository;
+
+    final preferencesServiceMock = MockPreferencesService();
+
+    setUpAll(() {
+      locator.registerSingleton<PreferencesService>(preferencesServiceMock);
+    });
+
+    setUp(() {
+      repository = SettingsRepository();
+    });
+
+    tearDown(() {
+      reset(preferencesServiceMock);
+    });
+
+    tearDownAll(() {
+      unregister<PreferencesService>();
+    });
+
+    group("Theme mode", () {
+      group("get", () {
+        test("should return the ThemeMode.system when no theme is found",
+            () async {
+          await repository.loadSettings();
+
+          expect(repository.themeMode, ThemeMode.system,
+              reason:
+                  "No theme mode is saved or the saved one is invalid, instead should return system.");
+          verify(preferencesServiceMock.getString(PreferenceFlags.themeMode));
+        });
+
+        test("should return the saved theme mode", () async {
+          when(preferencesServiceMock.getString(PreferenceFlags.themeMode))
+              .thenAnswer((_) async => ThemeMode.dark.toString());
+          await repository.loadSettings();
+
+          expect(repository.themeMode, ThemeMode.dark);
+          verify(preferencesServiceMock.getString(PreferenceFlags.themeMode));
+        });
+      });
+
+      group("update", () {
+        int fired = 0;
+
+        void listener() {
+          fired++;
+        }
+
+        setUp(() {
+          fired = 0;
+          repository.addListener(listener);
+        });
+
+        tearDown(() => repository.removeListener(listener));
+
+        test("should update the theme and notify listener", () async {
+          await repository.loadSettings();
+
+          const newMode = ThemeMode.dark;
+
+          expect(repository.themeMode, ThemeMode.system,
+              reason:
+                  "No theme mode is saved or the saved one is invalid, instead should return system.");
+          await repository.updateThemeMode(newMode);
+          expect(repository.themeMode, newMode,
+              reason: "Mode should have been updated");
+          expect(fired, 2,
+              reason:
+                  "Listener should have been notified 2 times, during loadSettings and updateThemeMode");
+          verifyInOrder([
+            preferencesServiceMock.getString(PreferenceFlags.themeMode),
+            preferencesServiceMock.setString(
+                PreferenceFlags.themeMode, newMode.toString())
+          ]);
+          verifyNoMoreInteractions(preferencesServiceMock);
+        });
+
+        test("should not update the theme", () async {
+          await repository.loadSettings();
+
+          const newMode = ThemeMode.system;
+
+          expect(repository.themeMode, ThemeMode.system,
+              reason:
+              "No theme mode is saved or the saved one is invalid, instead should return system.");
+          await repository.updateThemeMode(newMode);
+          expect(repository.themeMode, ThemeMode.system,
+              reason: "Mode should not have change");
+          expect(fired, 1,
+              reason:
+              "Listener should have been notified 1 time during loadSettings");
+          verifyInOrder([
+            preferencesServiceMock.getString(PreferenceFlags.themeMode),
+          ]);
+          verifyNoMoreInteractions(preferencesServiceMock);
+        });
+      });
+    });
+  });
+}

--- a/test/src/core/services/preferences_service_test.dart
+++ b/test/src/core/services/preferences_service_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kana_to_kanji/src/core/constants/preference_flags.dart';
+import 'package:kana_to_kanji/src/core/services/preferences_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  SharedPreferences? sharedPreferences;
+
+  PreferencesService? service;
+
+  SharedPreferences.setMockInitialValues({});
+
+  group("PreferencesService", () {
+    setUp(() async {
+      sharedPreferences = await SharedPreferences.getInstance();
+
+      service = PreferencesService();
+    });
+
+    group("setters", () {
+      test("setBool", () async {
+        expect(await service!.setBool(PreferenceFlags.themeMode, true), isTrue);
+        expect(sharedPreferences!.getBool(PreferenceFlags.themeMode.toString()),
+            isTrue);
+      });
+
+      test("setString", () async {
+        expect(await service!.setString(PreferenceFlags.themeMode, "Test"),
+            isTrue);
+        expect(
+            sharedPreferences!.getString(PreferenceFlags.themeMode.toString()),
+            "Test");
+      });
+
+      test("setInt", () async {
+        expect(await service!.setInt(PreferenceFlags.themeMode, 1), isTrue);
+        expect(
+            sharedPreferences!.getInt(PreferenceFlags.themeMode.toString()), 1);
+      });
+
+      test("setDateTime", () async {
+        expect(
+            await service!
+                .setDateTime(PreferenceFlags.themeMode, DateTime(2000, 01, 02)),
+            isTrue);
+        expect(
+            sharedPreferences!.getString(PreferenceFlags.themeMode.toString()),
+            DateTime(2000, 01, 02).toIso8601String());
+      });
+    });
+
+    test("clear", () async {
+      SharedPreferences.setMockInitialValues(
+          {PreferenceFlags.themeMode.toString(): true});
+
+      expect(await service!.getBool(PreferenceFlags.themeMode), isTrue);
+
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      prefs.clear();
+
+      expect(await service!.getBool(PreferenceFlags.themeMode), null);
+    });
+
+    group("getters", () {
+      test("getBool", () async {
+        SharedPreferences.setMockInitialValues(
+            {PreferenceFlags.themeMode.toString(): true});
+
+        expect(await service!.getBool(PreferenceFlags.themeMode), isTrue);
+      });
+
+      test("getString", () async {
+        SharedPreferences.setMockInitialValues(
+            {PreferenceFlags.themeMode.toString(): "Test"});
+
+        expect(await service!.getString(PreferenceFlags.themeMode), "Test");
+      });
+
+      test("getInt", () async {
+        SharedPreferences.setMockInitialValues(
+            {PreferenceFlags.themeMode.toString(): 1});
+
+        expect(await service!.getInt(PreferenceFlags.themeMode), 1);
+      });
+
+      test("getDateTime", () async {
+        SharedPreferences.setMockInitialValues({
+          PreferenceFlags.themeMode.toString():
+          DateTime(2000, 01, 02).toIso8601String()
+        });
+
+        expect(await service!.getDateTime(PreferenceFlags.themeMode),
+            DateTime(2000, 01, 02));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## 📖 Description
<!--- Describe your changes in detail -->

- Implement PreferencesService to store simple data like the user preferences directly in the device (outside the DB)
- Implement `SettingsRepository.themeMode`
- Link `SettingsViewModel` and `SettingsRepository` to use the newly created `themeMode`

### ⁉️ Related Issues
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--- Please link the issue here: (use keyword `closes: #12345`) -->

partial of #30 

<!--- If it's a visual change, please provide a screenshot/video of the changes -->
### 🖼️ Screenshots:
<!--- Use the spoiler system for your screenshots/videos -->

<details>
    <summary>Demonstration of theme mode persistance</summary> 

https://github.com/RoadTripMoustache/kana_to_kanji/assets/22211097/c660b33e-03ed-4ce6-a8cf-08f9127c24fe

</details>

### 🧪 How to test the change?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your unit test, and the manual tests you did -->
<!--- see how your change affects other areas of the code, etc. -->

- Update the router to start the application on `SettingsView.routeName`
- Change the theme mode that pleases you.
- Close the application
- Start it up again
- See changes

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [ ] ~Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.~