### PR TITLE
ci: Split the android build per abi to reduce apk size

### DIFF
--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -131,6 +131,7 @@ jobs:
       - name: Rename Android build
         if: matrix.target == 'Android'
         run: |
+          sudo apt-get install rename
           rename 's/app-(.+)-(.*)-release.apk/${{ vars.APP_NAME }}_${{ env.VERSION }}_${{ matrix.target }}_$1.${{ matrix.asset_extension }}/' *.apk
           mv *.apk ${{ github.workspace }}/
         working-directory: ${{ matrix.build_path }}

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -75,20 +75,20 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - iOS
-          - Android
+          - ios
+          - android
         include:
-          - target: iOS
+          - target: ios
             os: macos-latest
             build_target: ios
             build_args: --no-codesign
             build_path: build/ios/iphoneos
             asset_extension: zip
             asset_content_type: application/zip
-          - target: Android
+          - target: android
             os: ubuntu-latest
             build_target: apk
-            build_args: ''
+            build_args: --split-per-abi
             build_path: build/app/outputs/flutter-apk
             asset_extension: apk
             asset_content_type: application/zip
@@ -131,7 +131,8 @@ jobs:
       - name: Rename Android build
         if: matrix.target == 'Android'
         run: |
-          mv app-prod-release.${{ matrix.asset_extension }} ${{ github.workspace }}/${{ vars.APP_NAME }}_${{ env.VERSION }}_${{ matrix.target }}.${{ matrix.asset_extension }}
+          rename 's/app-(.+)-(.*)-release.apk/${{ vars.APP_NAME }}_${{ env.VERSION }}_${{ matrix.target }}_$1.${{ matrix.asset_extension }}/' *.apk
+          mv *.apk ${{ github.workspace }}/
         working-directory: ${{ matrix.build_path }}
 
       - name: Compress iOS build

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -179,5 +179,5 @@ jobs:
           path: build
       - name: List directory content
         run: |
-          ls -ali
+          ls -ali */**
         working-directory: build

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -97,20 +97,20 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - iOS
-          - Android
+          - ios
+          - android
         include:
-          - target: iOS
+          - target: ios
             os: macos-latest
             build_target: ios
             build_args: --no-codesign
             build_path: build/ios/iphoneos
             asset_extension: zip
             asset_content_type: application/zip
-          - target: Android
+          - target: android
             os: ubuntu-latest
             build_target: apk
-            build_args: ''
+            build_args: --split-per-abi
             build_path: build/app/outputs/flutter-apk
             asset_extension: apk
             asset_content_type: application/zip
@@ -154,17 +154,18 @@ jobs:
       - name: Rename Android build
         if: matrix.target == 'Android'
         run: |
-          mv app-${{ env.FLAVOR }}-release.${{ matrix.asset_extension }} ${{ github.workspace }}/${{ vars.DEV_APP_NAME }}_${{ env.FLAVOR }}_${{ env.VERSION }}_${{ matrix.target }}.${{ matrix.asset_extension }}
+          rename 's/app-(.+)-(.*)-release/${{ vars.APP_NAME }}_${{ env.VERSION }}_$2_${{ matrix.target }}_$1/' *.apk
+          mv *.apk ${{ github.workspace }}/
         working-directory: ${{ matrix.build_path }}
 
       - name: Compress iOS build
         if: matrix.target == 'iOS'
         run: |
-          ditto -c -k --sequesterRsrc --keepParent ${{ vars.DEV_APP_NAME }}.app ${{ github.workspace }}/${{ vars.DEV_APP_NAME }}_${{ env.FLAVOR }}_${{ env.VERSION }}_${{ matrix.target }}.${{ matrix.asset_extension }}
+          ditto -c -k --sequesterRsrc --keepParent ${{ vars.DEV_APP_NAME }}.app ${{ github.workspace }}/${{ vars.APP_NAME }}_${{ env.VERSION }}_${{ env.FLAVOR }}_${{ matrix.target }}.${{ matrix.asset_extension }}
         working-directory: ${{ matrix.build_path }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}
-          path: ${{ github.workspace }}/${{ vars.DEV_APP_NAME }}_${{ env.FLAVOR }}_${{ env.VERSION }}_${{ matrix.target }}.${{ matrix.asset_extension }}
+          path: ${{ github.workspace }}/${{ vars.APP_NAME }}_${{ env.VERSION }}_${{ env.FLAVOR }}_${{ matrix.target }}*.${{ matrix.asset_extension }}

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -17,27 +17,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bump_version:
-    name: Bump version
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'main'
-    outputs:
-      stop: ${{ steps.bump.outputs.has_changed }}
-      version: ${{ steps.bump.outputs.version }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Bump version using labels
-        id: bump
-        uses: apomalyn/bump-version-using-labels@v1.5.0
-        with:
-          file_path: 'pubspec.yaml'
-          reference_branch: 'main'
+#  bump_version:
+#    name: Bump version
+#    runs-on: ubuntu-latest
+#    if: github.event.pull_request.base.ref == 'main'
+#    outputs:
+#      stop: ${{ steps.bump.outputs.has_changed }}
+#      version: ${{ steps.bump.outputs.version }}
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Bump version using labels
+#        id: bump
+#        uses: apomalyn/bump-version-using-labels@v1.5.0
+#        with:
+#          file_path: 'pubspec.yaml'
+#          reference_branch: 'main'
   tests:
     name: Run the tests and checks
     runs-on: ubuntu-latest
-#    needs:
-#      - bump_version
-#    if: needs.bump_version.outputs.stop == 'false'
     outputs:
       coverage: ${{ steps.coverage.outputs.percentage }}
     steps:

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -151,6 +151,7 @@ jobs:
       - name: Rename Android build
         if: matrix.target == 'Android'
         run: |
+          sudo apt-get install rename
           rename 's/app-(.+)-(.*)-release/${{ vars.APP_NAME }}_${{ env.VERSION }}_$2_${{ matrix.target }}_$1/' *.apk
           mv *.apk ${{ github.workspace }}/
         working-directory: ${{ matrix.build_path }}

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -5,7 +5,7 @@ on:
       - '.gitignore'
       - '.metadata'
       - 'README.md'
-#      - '.github/**'
+      - '.github/**'
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
@@ -17,21 +17,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-#  bump_version:
-#    name: Bump version
-#    runs-on: ubuntu-latest
-#    if: github.event.pull_request.base.ref == 'main'
-#    outputs:
-#      stop: ${{ steps.bump.outputs.has_changed }}
-#      version: ${{ steps.bump.outputs.version }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Bump version using labels
-#        id: bump
-#        uses: apomalyn/bump-version-using-labels@v1.5.0
-#        with:
-#          file_path: 'pubspec.yaml'
-#          reference_branch: 'main'
+  bump_version:
+    name: Bump version
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'main'
+    outputs:
+      stop: ${{ steps.bump.outputs.has_changed }}
+      version: ${{ steps.bump.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bump version using labels
+        id: bump
+        uses: apomalyn/bump-version-using-labels@v1.5.0
+        with:
+          file_path: 'pubspec.yaml'
+          reference_branch: 'main'
   tests:
     name: Run the tests and checks
     runs-on: ubuntu-latest
@@ -167,17 +167,3 @@ jobs:
         with:
           name: ${{ matrix.target }}
           path: ${{ github.workspace }}/${{ vars.APP_NAME }}_${{ env.VERSION }}_${{ env.FLAVOR }}_${{ matrix.target }}*.${{ matrix.asset_extension }}
-  tmp:
-    name: Test
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download build of Android and iOS
-        uses: actions/download-artifact@v3
-        with:
-          path: build
-      - name: List directory content
-        run: |
-          ls -ali */**
-        working-directory: build

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -5,7 +5,7 @@ on:
       - '.gitignore'
       - '.metadata'
       - 'README.md'
-      - '.github/**'
+#      - '.github/**'
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -167,3 +167,17 @@ jobs:
         with:
           name: ${{ matrix.target }}
           path: ${{ github.workspace }}/${{ vars.APP_NAME }}_${{ env.VERSION }}_${{ env.FLAVOR }}_${{ matrix.target }}*.${{ matrix.asset_extension }}
+  tmp:
+    name: Test
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build of Android and iOS
+        uses: actions/download-artifact@v3
+        with:
+          path: build
+      - name: List directory content
+        run: |
+          ls -ali
+        working-directory: build


### PR DESCRIPTION
## 📖 Description
<!--- Describe your changes in detail -->

Change how we build android to split the build by abi, reducing the size of the build.

Make all the necessary modifications to upload all the apk.


### ⁉️ Related Issues
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--- Please link the issue here: (use keyword `closes: #12345`) -->

❌ 

<!--- If it's a visual change, please provide a screenshot/video of the changes -->
### 🖼️ Screenshots:
<!--- Use the spoiler system for your screenshots/videos -->

❌ 

### 🧪 How to test the change?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your unit test, and the manual tests you did -->
<!--- see how your change affects other areas of the code, etc. -->

❌ 

### ☑️ Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] I have added/updated tests.
- [ ] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.