### PR TITLE
feat: Add language configuration in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ dart pub global activate flutterfire_cli
 ## Login into Firebase 
 firebase login
 ## Generate firebase files
-flutterfire configure --project=kana-to-kanji-dev\
+flutterfire configure --project=<firebase-project-id>\
    --platforms=android,ios,web \
-   --android-package-name=com.roadtripmoustache.kana_to_kanji.dev \
-   --ios-bundle-id=com.roadtripmoustache.kana-to-kanji.dev \
+   --android-package-name=com.roadtripmoustache.kana_to_kanji[.<flavor>] \
+   --ios-bundle-id=com.roadtripmoustache.kana-to-kanji[.<flavor>] \
    --out=lib/firebase_options.dart
 
 # Get the dependencies and generate l10n files

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ dart pub global activate flutterfire_cli
 ## Login into Firebase 
 firebase login
 ## Generate firebase files
-flutterfire configure --project=<firebase-project-name>\
-   --platforms=android,ios \
-   --android-package-name=com.roadtripmoustache.kana_to_kanji[.<flavor>] \
-   --ios-bundle-id=com.roadtripmoustache.kana-to-kanji[.<flavor>] \
+flutterfire configure --project=kana-to-kanji-dev\
+   --platforms=android,ios,web \
+   --android-package-name=com.roadtripmoustache.kana_to_kanji.dev \
+   --ios-bundle-id=com.roadtripmoustache.kana-to-kanji.dev \
    --out=lib/firebase_options.dart
 
 # Get the dependencies and generate l10n files
@@ -56,7 +56,7 @@ flutter run --flavor <flavor> [--target lib/main_<flavor>.dart]
 This project has three (3) flavors:
 - Prod
 - Beta, target to specify `lib/main_beta.dart`
-- Dev, target to specify `lib/main_dev.dart`
+- Dev, target to specify `lib/main_dev.dart` - **Must use this flavor for web**
 
 
 #### Troubleshoot

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,7 +1,6 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,6 +1,8 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -56,6 +58,7 @@ class KanaToKanjiApp extends StatelessWidget {
               supportedLocales: AppLocalizations.supportedLocales,
               onGenerateTitle: (BuildContext context) =>
                   AppLocalizations.of(context).app_title,
+              locale: _settingsRepository.locale ?? Localizations.maybeLocaleOf(context) ?? Locale.fromSubtags(languageCode: Platform.localeName.split('_')[0]),
 
               // Theme
               theme: AppTheme.light(),

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -58,7 +58,7 @@ class KanaToKanjiApp extends StatelessWidget {
               supportedLocales: AppLocalizations.supportedLocales,
               onGenerateTitle: (BuildContext context) =>
                   AppLocalizations.of(context).app_title,
-              locale: _settingsRepository.locale ?? Localizations.maybeLocaleOf(context) ?? Locale.fromSubtags(languageCode: Platform.localeName.split('_')[0]),
+              locale: _settingsRepository.locale,
 
               // Theme
               theme: AppTheme.light(),

--- a/lib/src/core/constants/preference_flags.dart
+++ b/lib/src/core/constants/preference_flags.dart
@@ -1,1 +1,4 @@
-enum PreferenceFlags { themeMode }
+enum PreferenceFlags {
+  themeMode,
+  locale,
+}

--- a/lib/src/core/repositories/settings_repository.dart
+++ b/lib/src/core/repositories/settings_repository.dart
@@ -7,8 +7,10 @@ class SettingsRepository with ChangeNotifier {
   final PreferencesService _preferencesService = locator<PreferencesService>();
 
   late ThemeMode _themeMode;
+  late Locale? _locale;
 
   ThemeMode get themeMode => _themeMode;
+  Locale? get locale => _locale;
 
   int getMaximumAttemptsByQuestion() {
     return 3;
@@ -22,6 +24,14 @@ class SettingsRepository with ChangeNotifier {
     _themeMode = ThemeMode.values.firstWhere((e) => e.toString() == modeValue,
         orElse: () => ThemeMode.system);
 
+    String? localeValue =
+        await _preferencesService.getString(PreferenceFlags.locale);
+
+    _locale = null;
+    if (localeValue != null) {
+      _locale = Locale.fromSubtags(languageCode: localeValue);
+    }
+
     notifyListeners();
   }
 
@@ -34,5 +44,16 @@ class SettingsRepository with ChangeNotifier {
     notifyListeners();
     await _preferencesService.setString(
         PreferenceFlags.themeMode, newThemeMode.toString());
+  }
+
+  /// Update and persist the Locale based on the user's selection.
+  Future<void> updateLocale(Locale? newLocale) async {
+    if (newLocale == null || newLocale == _locale) return;
+
+    _locale = newLocale;
+
+    notifyListeners();
+    await _preferencesService.setString(
+        PreferenceFlags.locale, newLocale.languageCode);
   }
 }

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
@@ -49,6 +51,26 @@ class SettingsView extends StatelessWidget {
                                   message: value["tooltip"],
                                   child: Icon(value["icon"])))
                               .toList(growable: false),
+                        ),
+                      ),
+                      TileItem(
+                        title: Text(l10n.settings_language),
+                        trailing: DropdownButton<Locale>(
+                          value: viewModel.currentLocale ?? Localizations.localeOf(context),
+                          icon: const Icon(Icons.arrow_downward),
+                          style: const TextStyle(color: Colors.deepPurple),
+                          underline: Container(
+                            height: 2,
+                            color: Colors.deepPurpleAccent,
+                          ),
+                          onChanged: viewModel.setLocale,
+
+                          items: AppLocalizations.supportedLocales.map<DropdownMenuItem<Locale>>((Locale locale) {
+                            return DropdownMenuItem<Locale>(
+                              value: locale,
+                              child: Text(viewModel.languages(l10n)[locale.languageCode]!),
+                            );
+                          }).toList(),
                         ),
                       ),
                       HeadingItem(title: l10n.settings_legal_section),

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -67,7 +67,8 @@ class SettingsView extends StatelessWidget {
                               .map<DropdownMenuItem<Locale>>((Locale locale) {
                             return DropdownMenuItem<Locale>(
                               value: locale,
-                              child: Text(l10n.language(locale.languageCode, locale.languageCode)),
+                              child: Text(l10n.language(
+                                  locale.languageCode, locale.languageCode)),
                             );
                           }).toList(),
                         ),

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -67,8 +67,7 @@ class SettingsView extends StatelessWidget {
                               .map<DropdownMenuItem<Locale>>((Locale locale) {
                             return DropdownMenuItem<Locale>(
                               value: locale,
-                              child: Text(viewModel
-                                  .languages(l10n)[locale.languageCode]!),
+                              child: Text(l10n.language(locale.languageCode, locale.languageCode)),
                             );
                           }).toList(),
                         ),

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -67,8 +67,7 @@ class SettingsView extends StatelessWidget {
                               .map<DropdownMenuItem<Locale>>((Locale locale) {
                             return DropdownMenuItem<Locale>(
                               value: locale,
-                              child: Text(l10n.language(
-                                  locale.languageCode, locale.languageCode)),
+                              child: Text(l10n.language(locale.languageCode)),
                             );
                           }).toList(),
                         ),

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -56,7 +56,8 @@ class SettingsView extends StatelessWidget {
                       TileItem(
                         title: Text(l10n.settings_language),
                         trailing: DropdownButton<Locale>(
-                          value: viewModel.currentLocale ?? Localizations.localeOf(context),
+                          value: viewModel.currentLocale ??
+                              Localizations.localeOf(context),
                           icon: const Icon(Icons.arrow_downward),
                           style: const TextStyle(color: Colors.deepPurple),
                           underline: Container(
@@ -64,11 +65,12 @@ class SettingsView extends StatelessWidget {
                             color: Colors.deepPurpleAccent,
                           ),
                           onChanged: viewModel.setLocale,
-
-                          items: AppLocalizations.supportedLocales.map<DropdownMenuItem<Locale>>((Locale locale) {
+                          items: AppLocalizations.supportedLocales
+                              .map<DropdownMenuItem<Locale>>((Locale locale) {
                             return DropdownMenuItem<Locale>(
                               value: locale,
-                              child: Text(viewModel.languages(l10n)[locale.languageCode]!),
+                              child: Text(viewModel
+                                  .languages(l10n)[locale.languageCode]!),
                             );
                           }).toList(),
                         ),

--- a/lib/src/settings/settings_view_model.dart
+++ b/lib/src/settings/settings_view_model.dart
@@ -30,13 +30,6 @@ class SettingsViewModel extends BaseViewModel {
         },
       };
 
-  Map<String, String> languages(AppLocalizations a) {
-    return {
-      'en': a.language_en,
-      'fr': a.language_fr,
-    };
-  }
-
   ThemeMode get _themeMode => _repository.themeMode;
 
   Locale? get currentLocale => _repository.locale;

--- a/lib/src/settings/settings_view_model.dart
+++ b/lib/src/settings/settings_view_model.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:kana_to_kanji/src/core/repositories/settings_repository.dart';
 import 'package:kana_to_kanji/src/core/services/info_service.dart';
 import 'package:kana_to_kanji/src/locator.dart';
 import 'package:stacked/stacked.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class SettingsViewModel extends BaseViewModel {
   final SettingsRepository _repository = locator<SettingsRepository>();
@@ -30,7 +30,16 @@ class SettingsViewModel extends BaseViewModel {
         },
       };
 
+  Map<String, String> languages(AppLocalizations a) {
+    return {
+      'en': a.language_en,
+      'fr': a.language_fr,
+    };
+  }
+
   ThemeMode get _themeMode => _repository.themeMode;
+
+  Locale? get currentLocale => _repository.locale;
 
   List<bool> get themeModeSelected {
     final themeMode = _themeMode;
@@ -41,5 +50,9 @@ class SettingsViewModel extends BaseViewModel {
   Future<void> setThemeMode(int index) async {
     await _repository.updateThemeMode(themeModes.keys.elementAt(index));
     notifyListeners();
+  }
+
+  void setLocale(Locale? locale) async {
+    _repository.updateLocale(locale);
   }
 }

--- a/localization/en.arb
+++ b/localization/en.arb
@@ -112,8 +112,17 @@
     }
   },
   "settings_language": "Language",
-  "language_en": "English",
-  "language_fr": "French",
+  "language": "{languageCode, select, fr{Français} en{English} other{}}",
+  "@language": {
+     "description": "Display a language name based on the language code",
+     "placeholders": {
+       "shortCode": {
+         "type": "String",
+         "example": "fr",
+         "description": "Language code"
+       }
+     }
+  },
   "hiragana": "Hiragana ひらがな",
   "katakana": "Katakana カタカナ",
   "main_kana": "Main kana",

--- a/localization/en.arb
+++ b/localization/en.arb
@@ -111,6 +111,9 @@
       }
     }
   },
+  "settings_language": "Language",
+  "language_en": "English",
+  "language_fr": "French",
   "hiragana": "Hiragana ひらがな",
   "katakana": "Katakana カタカナ",
   "main_kana": "Main kana",

--- a/localization/en.arb
+++ b/localization/en.arb
@@ -116,7 +116,7 @@
   "@language": {
      "description": "Display a language name based on the language code",
      "placeholders": {
-       "shortCode": {
+       "languageCode": {
          "type": "String",
          "example": "fr",
          "description": "Language code"

--- a/localization/fr.arb
+++ b/localization/fr.arb
@@ -107,8 +107,17 @@
     }
   },
   "settings_language": "Langue",
-  "language_en": "Anglais",
-  "language_fr": "Français",
+  "language": "{languageCode, select, fr{Français} en{English} other{}}",
+  "@language": {
+    "description": "Display a language name based on the language code",
+    "placeholders": {
+      "shortCode": {
+        "type": "String",
+        "example": "fr",
+        "description": "Language code"
+      }
+    }
+  },
   "hiragana": "Hiragana ひらがな",
   "katakana": "Katakana カタカナ",
   "main_kana": "Kana principaux",

--- a/localization/fr.arb
+++ b/localization/fr.arb
@@ -111,7 +111,7 @@
   "@language": {
     "description": "Display a language name based on the language code",
     "placeholders": {
-      "shortCode": {
+      "languageCode": {
         "type": "String",
         "example": "fr",
         "description": "Language code"

--- a/localization/fr.arb
+++ b/localization/fr.arb
@@ -106,6 +106,9 @@
       }
     }
   },
+  "settings_language": "Langue",
+  "language_en": "Anglais",
+  "language_fr": "Français",
   "hiragana": "Hiragana ひらがな",
   "katakana": "Katakana カタカナ",
   "main_kana": "Kana principaux",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.6.1+1
+version: 0.7.0+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/test/src/core/repositories/settings_repository_test.dart
+++ b/test/src/core/repositories/settings_repository_test.dart
@@ -114,5 +114,95 @@ void main() {
         });
       });
     });
+
+    group("Locale", () {
+      group("get", () {
+        test("should return the null when no locale is found", () async {
+          await repository.loadSettings();
+
+          expect(
+              repository.locale,
+              null,
+              reason: "No locale saved, so it must be null."
+          );
+          verify(preferencesServiceMock.getString(PreferenceFlags.locale));
+        });
+
+        test("should return the saved theme mode", () async {
+          when(preferencesServiceMock.getString(PreferenceFlags.locale))
+              .thenAnswer((_) async => "fr");
+          await repository.loadSettings();
+
+          expect(repository.locale, const Locale.fromSubtags(languageCode: "fr"));
+          verify(preferencesServiceMock.getString(PreferenceFlags.locale));
+        });
+      });
+
+      group("update", () {
+        int fired = 0;
+
+        void listener() {
+          fired++;
+        }
+
+        setUp(() {
+          fired = 0;
+          repository.addListener(listener);
+        });
+
+        tearDown(() => repository.removeListener(listener));
+
+        test("should update the theme and notify listener", () async {
+          await repository.loadSettings();
+
+          const newLocale = Locale.fromSubtags(languageCode: "en");
+
+          expect(repository.themeMode, ThemeMode.system,
+              reason:
+                  "No theme mode is saved or the saved one is invalid, instead should return system.");
+          await repository.updateLocale(newLocale);
+          expect(repository.locale, newLocale,
+              reason: "Locale should have been updated");
+          expect(fired, 2,
+              reason:
+                  "Listener should have been notified 2 times, during loadSettings and updateLocale");
+          verifyInOrder([
+            preferencesServiceMock.getString(PreferenceFlags.themeMode),
+            preferencesServiceMock.getString(PreferenceFlags.locale),
+            preferencesServiceMock.setString(
+                PreferenceFlags.locale, newLocale.toString()),
+          ]);
+          verifyNoMoreInteractions(preferencesServiceMock);
+        });
+
+        test("should not update the locale", () async {
+          await repository.loadSettings();
+
+          expect(
+              repository.locale,
+              null,
+              reason: "No locale saved, so it must be null."
+          );
+
+          await repository.updateThemeMode(null);
+
+          expect(
+              repository.locale,
+              null,
+              reason: "Locale should not have change"
+          );
+          expect(
+              fired,
+              1,
+              reason: "Listener should have been notified 1 time during loadSettings"
+          );
+          verifyInOrder([
+            preferencesServiceMock.getString(PreferenceFlags.themeMode),
+            preferencesServiceMock.getString(PreferenceFlags.locale),
+          ]);
+          verifyNoMoreInteractions(preferencesServiceMock);
+        });
+      });
+    });
   });
 }

--- a/test/src/core/repositories/settings_repository_test.dart
+++ b/test/src/core/repositories/settings_repository_test.dart
@@ -85,8 +85,9 @@ void main() {
                   "Listener should have been notified 2 times, during loadSettings and updateThemeMode");
           verifyInOrder([
             preferencesServiceMock.getString(PreferenceFlags.themeMode),
+            preferencesServiceMock.getString(PreferenceFlags.locale),
             preferencesServiceMock.setString(
-                PreferenceFlags.themeMode, newMode.toString())
+                PreferenceFlags.themeMode, newMode.toString()),
           ]);
           verifyNoMoreInteractions(preferencesServiceMock);
         });
@@ -107,6 +108,7 @@ void main() {
                   "Listener should have been notified 1 time during loadSettings");
           verifyInOrder([
             preferencesServiceMock.getString(PreferenceFlags.themeMode),
+            preferencesServiceMock.getString(PreferenceFlags.locale),
           ]);
           verifyNoMoreInteractions(preferencesServiceMock);
         });

--- a/test/src/core/repositories/settings_repository_test.dart
+++ b/test/src/core/repositories/settings_repository_test.dart
@@ -120,11 +120,8 @@ void main() {
         test("should return the null when no locale is found", () async {
           await repository.loadSettings();
 
-          expect(
-              repository.locale,
-              null,
-              reason: "No locale saved, so it must be null."
-          );
+          expect(repository.locale, null,
+              reason: "No locale saved, so it must be null.");
           verify(preferencesServiceMock.getString(PreferenceFlags.locale));
         });
 
@@ -133,7 +130,8 @@ void main() {
               .thenAnswer((_) async => "fr");
           await repository.loadSettings();
 
-          expect(repository.locale, const Locale.fromSubtags(languageCode: "fr"));
+          expect(
+              repository.locale, const Locale.fromSubtags(languageCode: "fr"));
           verify(preferencesServiceMock.getString(PreferenceFlags.locale));
         });
       });
@@ -178,24 +176,16 @@ void main() {
         test("should not update the locale", () async {
           await repository.loadSettings();
 
-          expect(
-              repository.locale,
-              null,
-              reason: "No locale saved, so it must be null."
-          );
+          expect(repository.locale, null,
+              reason: "No locale saved, so it must be null.");
 
           await repository.updateThemeMode(null);
 
-          expect(
-              repository.locale,
-              null,
-              reason: "Locale should not have change"
-          );
-          expect(
-              fired,
-              1,
-              reason: "Listener should have been notified 1 time during loadSettings"
-          );
+          expect(repository.locale, null,
+              reason: "Locale should not have change");
+          expect(fired, 1,
+              reason:
+                  "Listener should have been notified 1 time during loadSettings");
           verifyInOrder([
             preferencesServiceMock.getString(PreferenceFlags.themeMode),
             preferencesServiceMock.getString(PreferenceFlags.locale),


### PR DESCRIPTION
## 📖 Description
Add language configuration in settings

### ⁉️ Related Issues
#56 

### 🖼️ Screenshots:
<!--- Use the spoiler system for your screenshots/videos -->

<details>
    <summary>Changing language in setting</summary> 
    [config_changement_langue2.webm](https://github.com/RoadTripMoustache/kana_to_kanji/assets/36586573/7c24ca90-a5be-4667-8b43-e813857a5ce5)
</details>

### 🧪 How to test the change?
- Start the application
- Go to the settings
- Change language

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.