### PR TITLE
feat(#92): Implement bottom bar navigation

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -48,9 +48,10 @@ class KanaToKanjiApp extends StatelessWidget {
     await locator<SettingsRepository>().loadSettings();
   }
 
+  late final _router = buildRouter(locator<DialogService>().navigatorKey);
+
   @override
   Widget build(BuildContext context) {
-    final router = buildRouter(locator<DialogService>().navigatorKey);
     return AnimatedBuilder(
         animation: _settingsRepository,
         builder: (BuildContext context, _) {
@@ -78,7 +79,7 @@ class KanaToKanjiApp extends StatelessWidget {
                 themeMode: _settingsRepository.themeMode,
 
                 // Router
-                routerConfig: router),
+                routerConfig: _router),
           );
         });
   }

--- a/lib/src/core/models/app_navigation_destination.dart
+++ b/lib/src/core/models/app_navigation_destination.dart
@@ -9,16 +9,12 @@ class AppNavigationDestination with _$AppNavigationDestination {
 
   const factory AppNavigationDestination(
       {required Widget icon,
-        required String location,
-        required String label,
-        Widget? selectedIcon,
-        Color? backgroundColor,
-        String? tooltip}) = _AppNavigationDestination;
+      required String location,
+      required String label,
+      Widget? selectedIcon,
+      Color? backgroundColor,
+      String? tooltip}) = _AppNavigationDestination;
 
-  NavigationDestination get navigationDestination =>
-      NavigationDestination(
-          icon: icon,
-          selectedIcon: selectedIcon,
-          label: label,
-          tooltip: tooltip);
+  NavigationDestination get navigationDestination => NavigationDestination(
+      icon: icon, selectedIcon: selectedIcon, label: label, tooltip: tooltip);
 }

--- a/lib/src/core/models/app_navigation_destination.dart
+++ b/lib/src/core/models/app_navigation_destination.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'app_navigation_destination.freezed.dart';
+
+@freezed
+class AppNavigationDestination with _$AppNavigationDestination {
+  const AppNavigationDestination._();
+
+  const factory AppNavigationDestination(
+      {required Widget icon,
+        required String location,
+        required String label,
+        Widget? selectedIcon,
+        Color? backgroundColor,
+        String? tooltip}) = _AppNavigationDestination;
+
+  NavigationDestination get navigationDestination =>
+      NavigationDestination(
+          icon: icon,
+          selectedIcon: selectedIcon,
+          label: label,
+          tooltip: tooltip);
+}

--- a/lib/src/core/widgets/app_bottom_navigation_bar.dart
+++ b/lib/src/core/widgets/app_bottom_navigation_bar.dart
@@ -13,43 +13,43 @@ class AppBottomNavigationBar extends StatelessWidget {
     final router = GoRouter.of(context);
 
     final tabs = _buildDestinations(l10n);
-    final selectedIndex = tabs.indexWhere((t) => router
-        .routerDelegate.currentConfiguration.uri
-        .toString()
-        .startsWith(t.location));
+    final currentRoute =
+        GoRouter.of(context).routeInformationProvider.value.uri.path;
+    final selectedIndex =
+        tabs.indexWhere((t) => currentRoute.startsWith(t.location));
 
     return NavigationBar(
-        selectedIndex: selectedIndex,
+        selectedIndex: selectedIndex < 0 ? 0 : selectedIndex,
         onDestinationSelected: (index) => router.go(tabs[index].location),
         destinations:
             tabs.map((e) => e.navigationDestination).toList(growable: false));
   }
 
   List<AppNavigationDestination> _buildDestinations(AppLocalizations l10n) => [
-        // AppNavigationDestination(
-        //     icon: const Icon(Icons.home_outlined),
-        //     selectedIcon: const Icon(Icons.home_rounded),
-        //     label: l10n.app_bottom_bar_home,
-        //     location: "/home"),
-        // AppNavigationDestination(
-        //     icon: const Icon(Icons.school_outlined),
-        //     selectedIcon: const Icon(Icons.school_rounded),
-        //     label: l10n.app_bottom_bar_lesson,
-        //     location: "/lesson"),
+        AppNavigationDestination(
+            icon: const Icon(Icons.home_outlined),
+            selectedIcon: const Icon(Icons.home_rounded),
+            label: l10n.app_bottom_bar_home,
+            location: "/home"),
+        AppNavigationDestination(
+            icon: const Icon(Icons.school_outlined),
+            selectedIcon: const Icon(Icons.school_rounded),
+            label: l10n.app_bottom_bar_lesson,
+            location: "/lesson"),
         AppNavigationDestination(
             icon: const Icon(Icons.psychology_outlined),
             selectedIcon: const Icon(Icons.psychology_rounded),
             label: l10n.app_bottom_bar_practice,
             location: PrepareQuizView.routeName),
-        // AppNavigationDestination(
-        //     icon: const Icon(Icons.menu_book_outlined),
-        //     selectedIcon: const Icon(Icons.menu_book_rounded),
-        //     label: l10n.app_bottom_bar_glossary,
-        //     location: "/glossary"),
-        // AppNavigationDestination(
-        //     icon: const Icon(Icons.account_circle_outlined),
-        //     selectedIcon: const Icon(Icons.account_circle_rounded),
-        //     label: l10n.app_bottom_bar_profile,
-        //     location: "/profile")
+        AppNavigationDestination(
+            icon: const Icon(Icons.menu_book_outlined),
+            selectedIcon: const Icon(Icons.menu_book_rounded),
+            label: l10n.app_bottom_bar_glossary,
+            location: "/glossary"),
+        AppNavigationDestination(
+            icon: const Icon(Icons.account_circle_outlined),
+            selectedIcon: const Icon(Icons.account_circle_rounded),
+            label: l10n.app_bottom_bar_profile,
+            location: "/profile")
       ];
 }

--- a/lib/src/core/widgets/app_bottom_navigation_bar.dart
+++ b/lib/src/core/widgets/app_bottom_navigation_bar.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kana_to_kanji/src/core/models/app_navigation_destination.dart';
+import 'package:kana_to_kanji/src/quiz/prepare/prepare_quiz_view.dart';
+
+class AppBottomNavigationBar extends StatelessWidget {
+  const AppBottomNavigationBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final router = GoRouter.of(context);
+
+    final tabs = _buildDestinations(l10n);
+    final selectedIndex = tabs.indexWhere((t) => router
+        .routerDelegate.currentConfiguration.uri
+        .toString()
+        .startsWith(t.location));
+
+    return NavigationBar(
+        selectedIndex: selectedIndex,
+        onDestinationSelected: (index) => router.go(tabs[index].location),
+        destinations:
+            tabs.map((e) => e.navigationDestination).toList(growable: false));
+  }
+
+  List<AppNavigationDestination> _buildDestinations(AppLocalizations l10n) => [
+        // AppNavigationDestination(
+        //     icon: const Icon(Icons.home_outlined),
+        //     selectedIcon: const Icon(Icons.home_rounded),
+        //     label: l10n.app_bottom_bar_home,
+        //     location: "/home"),
+        // AppNavigationDestination(
+        //     icon: const Icon(Icons.school_outlined),
+        //     selectedIcon: const Icon(Icons.school_rounded),
+        //     label: l10n.app_bottom_bar_lesson,
+        //     location: "/lesson"),
+        AppNavigationDestination(
+            icon: const Icon(Icons.psychology_outlined),
+            selectedIcon: const Icon(Icons.psychology_rounded),
+            label: l10n.app_bottom_bar_practice,
+            location: PrepareQuizView.routeName),
+        // AppNavigationDestination(
+        //     icon: const Icon(Icons.menu_book_outlined),
+        //     selectedIcon: const Icon(Icons.menu_book_rounded),
+        //     label: l10n.app_bottom_bar_glossary,
+        //     location: "/glossary"),
+        // AppNavigationDestination(
+        //     icon: const Icon(Icons.account_circle_outlined),
+        //     selectedIcon: const Icon(Icons.account_circle_rounded),
+        //     label: l10n.app_bottom_bar_profile,
+        //     location: "/profile")
+      ];
+}

--- a/lib/src/core/widgets/app_bottom_navigation_bar.dart
+++ b/lib/src/core/widgets/app_bottom_navigation_bar.dart
@@ -26,16 +26,16 @@ class AppBottomNavigationBar extends StatelessWidget {
   }
 
   List<AppNavigationDestination> _buildDestinations(AppLocalizations l10n) => [
-        AppNavigationDestination(
-            icon: const Icon(Icons.home_outlined),
-            selectedIcon: const Icon(Icons.home_rounded),
-            label: l10n.app_bottom_bar_home,
-            location: "/home"),
-        AppNavigationDestination(
-            icon: const Icon(Icons.school_outlined),
-            selectedIcon: const Icon(Icons.school_rounded),
-            label: l10n.app_bottom_bar_lesson,
-            location: "/lesson"),
+        // AppNavigationDestination(
+        //     icon: const Icon(Icons.home_outlined),
+        //     selectedIcon: const Icon(Icons.home_rounded),
+        //     label: l10n.app_bottom_bar_home,
+        //     location: "/home"),
+        // AppNavigationDestination(
+        //     icon: const Icon(Icons.school_outlined),
+        //     selectedIcon: const Icon(Icons.school_rounded),
+        //     label: l10n.app_bottom_bar_lesson,
+        //     location: "/lesson"),
         AppNavigationDestination(
             icon: const Icon(Icons.psychology_outlined),
             selectedIcon: const Icon(Icons.psychology_rounded),
@@ -46,10 +46,10 @@ class AppBottomNavigationBar extends StatelessWidget {
             selectedIcon: const Icon(Icons.menu_book_rounded),
             label: l10n.app_bottom_bar_glossary,
             location: "/glossary"),
-        AppNavigationDestination(
-            icon: const Icon(Icons.account_circle_outlined),
-            selectedIcon: const Icon(Icons.account_circle_rounded),
-            label: l10n.app_bottom_bar_profile,
-            location: "/profile")
+        // AppNavigationDestination(
+        //     icon: const Icon(Icons.account_circle_outlined),
+        //     selectedIcon: const Icon(Icons.account_circle_rounded),
+        //     label: l10n.app_bottom_bar_profile,
+        //     location: "/profile")
       ];
 }

--- a/lib/src/core/widgets/app_not_found_view.dart
+++ b/lib/src/core/widgets/app_not_found_view.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kana_to_kanji/src/core/widgets/app_scaffold.dart';
+
+class AppNotFoundView extends StatelessWidget {
+  final Uri uri;
+
+  final String goBackUrl;
+
+  const AppNotFoundView(
+      {super.key, required this.uri, required this.goBackUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context);
+
+    return AppScaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(l10n.page_not_found(uri.path)),
+            ElevatedButton(
+                onPressed: () => context.go(goBackUrl),
+                child: Text(l10n.go_home_button))
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/core/widgets/app_scaffold.dart
+++ b/lib/src/core/widgets/app_scaffold.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kana_to_kanji/src/core/widgets/app_bottom_navigation_bar.dart';
 
 /// Basic Scaffold to avoid boilerplate code in the application.
 class AppScaffold extends StatelessWidget {
@@ -12,13 +13,16 @@ class AppScaffold extends StatelessWidget {
 
   final bool resizeToAvoidBottomInset;
 
+  final bool showBottomBar;
+
   const AppScaffold(
       {super.key,
       this.appBar,
       required this.body,
       this.fab,
       this.fabPosition,
-      this.resizeToAvoidBottomInset = false});
+      this.resizeToAvoidBottomInset = false,
+      this.showBottomBar = false});
 
   @override
   Widget build(BuildContext context) => Scaffold(
@@ -30,6 +34,7 @@ class AppScaffold extends StatelessWidget {
           body,
         ]),
       ),
+      bottomNavigationBar: showBottomBar ? const AppBottomNavigationBar() : null,
       floatingActionButton: fab,
       floatingActionButtonLocation: fabPosition);
 }

--- a/lib/src/core/widgets/app_scaffold.dart
+++ b/lib/src/core/widgets/app_scaffold.dart
@@ -34,7 +34,8 @@ class AppScaffold extends StatelessWidget {
           body,
         ]),
       ),
-      bottomNavigationBar: showBottomBar ? const AppBottomNavigationBar() : null,
+      bottomNavigationBar:
+          showBottomBar ? const AppBottomNavigationBar() : null,
       floatingActionButton: fab,
       floatingActionButtonLocation: fabPosition);
 }

--- a/lib/src/quiz/prepare/prepare_quiz_view.dart
+++ b/lib/src/quiz/prepare/prepare_quiz_view.dart
@@ -20,6 +20,7 @@ class PrepareQuizView extends StatelessWidget {
     return ViewModelBuilder<PrepareQuizViewModel>.reactive(
       viewModelBuilder: () => PrepareQuizViewModel(GoRouter.of(context)),
       builder: (context, viewModel, _) => AppScaffold(
+          showBottomBar: true,
           appBar: AppBar(
             title: Text(l10n.quiz_build_title),
             centerTitle: true,

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:kana_to_kanji/src/core/widgets/app_scaffold.dart';
+import 'package:kana_to_kanji/src/core/widgets/app_not_found_view.dart';
 import 'package:kana_to_kanji/src/quiz/prepare/prepare_quiz_view.dart';
 import 'package:kana_to_kanji/src/core/models/group.dart';
 import 'package:kana_to_kanji/src/quiz/conclusion/quiz_conclusion_view.dart';
@@ -9,12 +9,13 @@ import 'package:kana_to_kanji/src/quiz/quiz_view.dart';
 import 'package:kana_to_kanji/src/settings/settings_view.dart';
 import 'package:kana_to_kanji/src/splash/splash_view.dart';
 
+const String _initialLocation = SplashView.routeName;
+
 GoRouter buildRouter([GlobalKey<NavigatorState>? key]) => GoRouter(
         navigatorKey: key,
-        initialLocation: SplashView.routeName,
-        errorBuilder: (context, state) => AppScaffold(
-              body: Center(child: Text("${state.path} wasn't found...")),
-            ),
+        initialLocation: _initialLocation,
+        errorBuilder: (context, state) =>
+            AppNotFoundView(uri: state.uri, goBackUrl: _initialLocation),
         routes: [
           GoRoute(
               path: SplashView.routeName,

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kana_to_kanji/src/core/widgets/app_scaffold.dart';
 import 'package:kana_to_kanji/src/quiz/prepare/prepare_quiz_view.dart';
 import 'package:kana_to_kanji/src/core/models/group.dart';
 import 'package:kana_to_kanji/src/quiz/conclusion/quiz_conclusion_view.dart';
@@ -8,41 +9,47 @@ import 'package:kana_to_kanji/src/quiz/quiz_view.dart';
 import 'package:kana_to_kanji/src/settings/settings_view.dart';
 import 'package:kana_to_kanji/src/splash/splash_view.dart';
 
-GoRouter buildRouter([GlobalKey<NavigatorState>? key]) =>
-    GoRouter(navigatorKey: key, initialLocation: SplashView.routeName, routes: [
-      GoRoute(
-          path: SplashView.routeName, builder: (_, __) => const SplashView()),
-      GoRoute(
-          path: PrepareQuizView.routeName,
-          builder: (_, __) => const PrepareQuizView(),
-          routes: [
-            GoRoute(
-                path: QuizView.routeName
-                    .substring(PrepareQuizView.routeName.length + 1),
-                redirect: (_, state) {
-                  if (state.extra is! List<Group>) {
-                    return "/error";
-                  }
-                  return null;
-                },
-                builder: (_, state) => QuizView(
-                      groups: state.extra as List<Group>,
-                    )),
-            GoRoute(
-                path: QuizConclusionView.routeName
-                    .substring(PrepareQuizView.routeName.length + 1),
-                redirect: (_, state) {
-                  if (state.extra is! List<Question>) {
-                    return "/error";
-                  }
-                  return null;
-                },
-                // +1 remove the /
-                builder: (_, state) => QuizConclusionView(
-                      questions: state.extra as List<Question>,
-                    ))
-          ]),
-      GoRoute(
-          path: SettingsView.routeName,
-          builder: (_, __) => const SettingsView())
-    ]);
+GoRouter buildRouter([GlobalKey<NavigatorState>? key]) => GoRouter(
+        navigatorKey: key,
+        initialLocation: SplashView.routeName,
+        errorBuilder: (context, state) => AppScaffold(
+              body: Center(child: Text("${state.path} wasn't found...")),
+            ),
+        routes: [
+          GoRoute(
+              path: SplashView.routeName,
+              builder: (_, __) => const SplashView()),
+          GoRoute(
+              path: PrepareQuizView.routeName,
+              builder: (_, __) => const PrepareQuizView(),
+              routes: [
+                GoRoute(
+                    path: QuizView.routeName
+                        .substring(PrepareQuizView.routeName.length + 1),
+                    redirect: (_, state) {
+                      if (state.extra is! List<Group>) {
+                        return "/error";
+                      }
+                      return null;
+                    },
+                    builder: (_, state) => QuizView(
+                          groups: state.extra as List<Group>,
+                        )),
+                GoRoute(
+                    path: QuizConclusionView.routeName
+                        .substring(PrepareQuizView.routeName.length + 1),
+                    redirect: (_, state) {
+                      if (state.extra is! List<Question>) {
+                        return "/error";
+                      }
+                      return null;
+                    },
+                    // +1 remove the /
+                    builder: (_, state) => QuizConclusionView(
+                          questions: state.extra as List<Question>,
+                        ))
+              ]),
+          GoRoute(
+              path: SettingsView.routeName,
+              builder: (_, __) => const SettingsView())
+        ]);

--- a/localization/en.arb
+++ b/localization/en.arb
@@ -9,6 +9,20 @@
   "app_bottom_bar_practice": "Practice",
   "app_bottom_bar_glossary": "Glossary",
   "app_bottom_bar_profile": "You",
+  "page_not_found": "The page you are search for ({uri}) wasn't found...",
+  "@page_not_found": {
+    "description": "Indication that the page search wasn't found",
+    "placeholders": {
+      "uri": {
+        "type": "String",
+        "example": "/home/you"
+      }
+    }
+  },
+  "go_home_button": "Go home",
+  "@go_home_button": {
+    "description": "Button text to return to home page"
+  },
   "button_continue": "Continue",
   "percent": "{percent}",
   "@percent": {

--- a/localization/en.arb
+++ b/localization/en.arb
@@ -4,6 +4,11 @@
   "app_title_kana": "Kana",
   "app_title_to": "と",
   "app_title_kanji": "kanji",
+  "app_bottom_bar_home": "Home",
+  "app_bottom_bar_lesson": "Learn",
+  "app_bottom_bar_practice": "Practice",
+  "app_bottom_bar_glossary": "Glossary",
+  "app_bottom_bar_profile": "You",
   "button_continue": "Continue",
   "percent": "{percent}",
   "@percent": {

--- a/localization/fr.arb
+++ b/localization/fr.arb
@@ -4,6 +4,11 @@
   "app_title_kana": "Kana",
   "app_title_to": "と",
   "app_title_kanji": "kanji",
+  "app_bottom_bar_home": "Home",
+  "app_bottom_bar_lesson": "Learn",
+  "app_bottom_bar_practice": "Practice",
+  "app_bottom_bar_glossary": "Glossary",
+  "app_bottom_bar_profile": "You",
   "button_continue": "Continuer",
   "percent": "{percent}",
   "@percent": {

--- a/localization/fr.arb
+++ b/localization/fr.arb
@@ -5,10 +5,24 @@
   "app_title_to": "と",
   "app_title_kanji": "kanji",
   "app_bottom_bar_home": "Home",
-  "app_bottom_bar_lesson": "Learn",
-  "app_bottom_bar_practice": "Practice",
-  "app_bottom_bar_glossary": "Glossary",
-  "app_bottom_bar_profile": "You",
+  "app_bottom_bar_lesson": "Apprend",
+  "app_bottom_bar_practice": "Pratique",
+  "app_bottom_bar_glossary": "Glossaire",
+  "app_bottom_bar_profile": "Toi",
+  "page_not_found": "La page que vous cherchez ({uri}) n'a pas été trouvé...",
+  "@page_not_found": {
+    "description": "Indique que la page recherchez n'a pas été trouvé",
+    "placeholders": {
+      "uri": {
+        "type": "String",
+        "example": "/home/you"
+      }
+    }
+  },
+  "go_home_button": "Retour à l'accueil",
+  "@go_home_button": {
+    "description": "Texte du bouton pour retourner a l'écran principal"
+  },
   "button_continue": "Continuer",
   "percent": "{percent}",
   "@percent": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.9.0+1
+version: 0.10.0+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -16,7 +16,10 @@ String getRouterKey(String route) {
   return 'key_$route';
 }
 
-extension RouterWidgetTester on WidgetTester {
+extension WidgetTesterExtension on WidgetTester {
+  /// Pump a router on [widget].
+  /// [initialLocation] is the current location of the widget and [allowedRoutes]
+  /// contains all the routes available for the router.
   Future<void> pumpRouterApp(Widget widget, String initialLocation,
       [List<String> allowedRoutes = const []]) {
     final router = GoRouter(
@@ -48,6 +51,9 @@ extension RouterWidgetTester on WidgetTester {
     );
   }
 
+  /// Pump a router on a localized [widget].
+  /// [initialLocation] is the current location of the widget and [allowedRoutes]
+  /// contains all the routes available for the router.
   Future<void> pumpLocalizedRouterWidget(Widget widget,
       {String initialLocation = "/",
       String locale = "en",
@@ -91,6 +97,7 @@ extension RouterWidgetTester on WidgetTester {
     );
   }
 
+  /// Pump a localized widget
   Future<void> pumpLocalizedWidget(Widget widget,
       {String locale = "en",
       double textScaleFactor = 0.9,

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -113,35 +113,3 @@ extension RouterWidgetTester on WidgetTester {
 Future<AppLocalizations> setupLocalizations([String locale = 'en']) async {
   return AppLocalizations.delegate.load(Locale(locale));
 }
-
-/// Load the l10n classes. Take the [child] widget to test
-@Deprecated("Use pumpLocalizedWidget instead")
-class LocalizedWidget extends StatelessWidget {
-  final Widget child;
-
-  final bool useScaffold;
-
-  final String locale;
-
-  final double textScaleFactor;
-
-  final ThemeMode themeMode;
-
-  const LocalizedWidget(
-      {super.key,
-      required this.child,
-      this.useScaffold = true,
-      this.locale = 'en',
-      this.textScaleFactor = 0.9,
-      this.themeMode = ThemeMode.light});
-
-  @override
-  Widget build(BuildContext context) => MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        theme: AppTheme.light(),
-        darkTheme: AppTheme.dark(),
-        themeMode: themeMode,
-        locale: Locale(locale),
-        home: useScaffold ? Scaffold(body: child) : child,
-      );
-}

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:kana_to_kanji/src/core/constants/app_theme.dart';
 import 'package:kana_to_kanji/src/locator.dart';
 
@@ -10,12 +12,110 @@ void unregister<T extends Object>() {
   }
 }
 
+String getRouterKey(String route) {
+  return 'key_$route';
+}
+
+extension RouterWidgetTester on WidgetTester {
+  Future<void> pumpRouterApp(Widget widget, String initialLocation,
+      [List<String> allowedRoutes = const []]) {
+    final router = GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        GoRoute(
+          path: initialLocation,
+          builder: (context, state) => widget,
+        ),
+        ...allowedRoutes
+            .map(
+              (e) => GoRoute(
+                path: e,
+                builder: (context, state) => Container(
+                  key: Key(
+                    getRouterKey(e),
+                  ),
+                ),
+              ),
+            )
+            .toList()
+      ],
+    );
+
+    return pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+      ),
+    );
+  }
+
+  Future<void> pumpLocalizedRouterWidget(Widget widget,
+      {String initialLocation = "/",
+      String locale = "en",
+      double textScaleFactor = 0.9,
+      ThemeMode themeMode = ThemeMode.light,
+      bool useScaffold = true,
+      Widget? allowedRoutesChild,
+      List<String> allowedRoutes = const []}) {
+    final router = GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        GoRoute(
+          path: initialLocation,
+          builder: (context, state) => Scaffold(body: widget),
+        ),
+        ...allowedRoutes
+            .map(
+              (e) => GoRoute(
+                path: e,
+                builder: (context, state) => Container(
+                  key: Key(
+                    getRouterKey(e),
+                  ),
+                  child: allowedRoutesChild,
+                ),
+              ),
+            )
+            .toList()
+      ],
+    );
+
+    return pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        theme: AppTheme.light(),
+        darkTheme: AppTheme.dark(),
+        themeMode: themeMode,
+        locale: Locale(locale),
+      ),
+    );
+  }
+
+  Future<void> pumpLocalizedWidget(Widget widget,
+      {String locale = "en",
+      double textScaleFactor = 0.9,
+      ThemeMode themeMode = ThemeMode.light,
+      bool useScaffold = true}) {
+    return pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        theme: AppTheme.light(),
+        darkTheme: AppTheme.dark(),
+        themeMode: themeMode,
+        locale: Locale(locale),
+        home: useScaffold ? Scaffold(body: widget) : widget,
+      ),
+    );
+  }
+}
+
 /// Load the l10n class
 Future<AppLocalizations> setupLocalizations([String locale = 'en']) async {
   return AppLocalizations.delegate.load(Locale(locale));
 }
 
 /// Load the l10n classes. Take the [child] widget to test
+@Deprecated("Use pumpLocalizedWidget instead")
 class LocalizedWidget extends StatelessWidget {
   final Widget child;
 

--- a/test/src/core/widgets/app_bottom_navigation_bar_test.dart
+++ b/test/src/core/widgets/app_bottom_navigation_bar_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kana_to_kanji/src/core/widgets/app_bottom_navigation_bar.dart';
+import 'package:kana_to_kanji/src/quiz/prepare/prepare_quiz_view.dart';
+
+import '../../../helpers.dart';
+
+void main() {
+  group("AppBottomNavigationBar", () {
+    testWidgets("should have 2 tabs", (WidgetTester tester) async {
+      final l10n = await setupLocalizations();
+
+      await tester.pumpLocalizedRouterWidget(const AppBottomNavigationBar(),
+          initialLocation: PrepareQuizView.routeName);
+      await tester.pumpAndSettle();
+
+      final widget = find.byType(AppBottomNavigationBar);
+
+      expect(widget, findsOneWidget);
+      expect(
+          find.descendant(
+              of: widget, matching: find.byType(NavigationDestination)),
+          findsNWidgets(2),
+          reason: "Should only have 2 tabs");
+
+      // Practice tab
+      Finder tab = find.ancestor(
+          of: find.text(l10n.app_bottom_bar_practice),
+          matching: find.byType(NavigationDestination));
+
+      expect(tab, findsOneWidget);
+      expect(
+          find.descendant(
+              of: tab, matching: find.byIcon(Icons.psychology_rounded)),
+          findsOneWidget,
+          reason:
+              "Practice icon should be psychology_rounded, as it's currently selected");
+
+      // Glossary tab
+      tab = find.ancestor(
+          of: find.text(l10n.app_bottom_bar_glossary),
+          matching: find.byType(NavigationDestination));
+
+      expect(tab, findsOneWidget);
+      expect(
+          find.descendant(
+              of: tab, matching: find.byIcon(Icons.menu_book_outlined)),
+          findsOneWidget,
+          reason: "Practice icon should be menu_book_outlined");
+    });
+
+    group("Behaviours", () {
+      testWidgets("should open the glossary", (WidgetTester tester) async {
+        final l10n = await setupLocalizations();
+
+        await tester.pumpLocalizedRouterWidget(const AppBottomNavigationBar(),
+            initialLocation: PrepareQuizView.routeName,
+            allowedRoutes: ["/glossary"],
+            allowedRoutesChild: const AppBottomNavigationBar());
+        await tester.pumpAndSettle();
+
+        // Glossary tab
+        Finder tab = find.ancestor(
+            of: find.text(l10n.app_bottom_bar_glossary),
+            matching: find.byType(NavigationDestination));
+
+        expect(tab, findsOneWidget);
+        expect(
+            find.descendant(
+                of: tab, matching: find.byIcon(Icons.menu_book_outlined)),
+            findsOneWidget,
+            reason: "Practice icon should be menu_book_outlined");
+
+        await tester.tap(find.descendant(
+            of: tab, matching: find.byIcon(Icons.menu_book_outlined)));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(Key(getRouterKey("/glossary"))), findsOneWidget);
+        expect(find.byIcon(Icons.menu_book_rounded), findsOneWidget,
+            reason:
+                "The selected icon of Glossary should be menu_book_rounded");
+      });
+    });
+  });
+}

--- a/test/src/core/widgets/arc_progress_indicator_test.dart
+++ b/test/src/core/widgets/arc_progress_indicator_test.dart
@@ -12,10 +12,9 @@ void main() {
         final l10n = await setupLocalizations();
         const value = 0.0;
 
-        await tester.pumpWidget(const LocalizedWidget(
-            child: ArcProgressIndicator(
+        await tester.pumpLocalizedWidget(const ArcProgressIndicator(
           value: value,
-        )));
+        ));
         await tester.pumpAndSettle();
 
         final widget = find.byType(ArcProgressIndicator);
@@ -31,11 +30,10 @@ void main() {
         final l10n = await setupLocalizations();
         const value = 0.0;
 
-        await tester.pumpWidget(const LocalizedWidget(
-            child: ArcProgressIndicator(
+        await tester.pumpLocalizedWidget(const ArcProgressIndicator(
           value: value,
           showPercentage: false,
-        )));
+        ));
         await tester.pumpAndSettle();
 
         final widget = find.byType(ArcProgressIndicator);
@@ -49,11 +47,10 @@ void main() {
 
       testWidgets("Custom radius", (WidgetTester tester) async {
         const double customRadius = 300.0;
-        await tester.pumpWidget(const LocalizedWidget(
-            child: ArcProgressIndicator(
+        await tester.pumpLocalizedWidget(const ArcProgressIndicator(
           value: 0.0,
           radius: customRadius,
-        )));
+        ));
         await tester.pumpAndSettle();
 
         final widget = find.byType(ArcProgressIndicator);
@@ -85,9 +82,8 @@ void main() {
 
         final l10n = await setupLocalizations();
 
-        await tester.pumpWidget(const LocalizedWidget(
-            child: ArcProgressIndicator(
-                value: value, alternativeText: alternativeText)));
+        await tester.pumpLocalizedWidget(const ArcProgressIndicator(
+            value: value, alternativeText: alternativeText));
         await tester.pumpAndSettle();
 
         final widget = find.byType(ArcProgressIndicator);
@@ -124,8 +120,8 @@ void main() {
 
         final l10n = await setupLocalizations();
 
-        await tester.pumpWidget(
-            const LocalizedWidget(child: ArcProgressIndicator(value: value)));
+        await tester
+            .pumpLocalizedWidget(const ArcProgressIndicator(value: value));
         await tester.pumpAndSettle();
 
         final widget = find.byType(ArcProgressIndicator);

--- a/test/src/feedback/widgets/feedback_form_test.dart
+++ b/test/src/feedback/widgets/feedback_form_test.dart
@@ -42,15 +42,14 @@ void main() {
         bool isSubmitEnabled = false,
         bool allowScreenshot = false,
         VoidCallback? onScreenshotButtonPressed}) async {
-      await tester.pumpWidget(LocalizedWidget(
-          child: FeedbackForm(
-              feedbackType: type,
-              onChange: mock.onChange,
-              validator: mock.validator,
-              onSubmit: mock.onSubmit,
-              isSubmitEnabled: isSubmitEnabled,
-              allowScreenshot: allowScreenshot,
-              onScreenshotButtonPressed: onScreenshotButtonPressed)));
+      await tester.pumpLocalizedWidget(FeedbackForm(
+          feedbackType: type,
+          onChange: mock.onChange,
+          validator: mock.validator,
+          onSubmit: mock.onSubmit,
+          isSubmitEnabled: isSubmitEnabled,
+          allowScreenshot: allowScreenshot,
+          onScreenshotButtonPressed: onScreenshotButtonPressed));
       await tester.pumpAndSettle();
 
       final widget = find.byType(FeedbackForm);

--- a/test/src/feedback/widgets/feedback_screenshot_form_test.dart
+++ b/test/src/feedback/widgets/feedback_screenshot_form_test.dart
@@ -29,7 +29,8 @@ void main() {
     });
 
     Future<Finder> buildWidget(WidgetTester tester) async {
-      await tester.pumpLocalizedWidget(FeedbackScreenshotForm(onSubmit: mock.onSubmit));
+      await tester
+          .pumpLocalizedWidget(FeedbackScreenshotForm(onSubmit: mock.onSubmit));
       await tester.pumpAndSettle();
 
       final widget = find.byType(FeedbackScreenshotForm);

--- a/test/src/feedback/widgets/feedback_screenshot_form_test.dart
+++ b/test/src/feedback/widgets/feedback_screenshot_form_test.dart
@@ -29,8 +29,7 @@ void main() {
     });
 
     Future<Finder> buildWidget(WidgetTester tester) async {
-      await tester.pumpWidget(LocalizedWidget(
-          child: FeedbackScreenshotForm(onSubmit: mock.onSubmit)));
+      await tester.pumpLocalizedWidget(FeedbackScreenshotForm(onSubmit: mock.onSubmit));
       await tester.pumpAndSettle();
 
       final widget = find.byType(FeedbackScreenshotForm);

--- a/test/src/feedback/widgets/feedback_success_dialog_test.dart
+++ b/test/src/feedback/widgets/feedback_success_dialog_test.dart
@@ -15,8 +15,7 @@ void main() {
 
     testWidgets("Should have a done green icon and thanks text",
         (WidgetTester tester) async {
-      await tester
-          .pumpWidget(const LocalizedWidget(child: FeedbackSuccessDialog()));
+      await tester.pumpLocalizedWidget(const FeedbackSuccessDialog());
       await tester.pumpAndSettle();
 
       final widget = find.byType(FeedbackSuccessDialog);

--- a/test/src/feedback/widgets/feedback_type_selection_test.dart
+++ b/test/src/feedback/widgets/feedback_type_selection_test.dart
@@ -16,8 +16,8 @@ void main() {
 
     testWidgets("Should display bug and feature request buttons",
         (WidgetTester tester) async {
-      await tester.pumpWidget(
-          LocalizedWidget(child: FeedbackTypeSelection(onPressed: (_) {})));
+      await tester
+          .pumpLocalizedWidget(FeedbackTypeSelection(onPressed: (_) {}));
       await tester.pumpAndSettle();
 
       final widget = find.byType(FeedbackTypeSelection);
@@ -72,8 +72,8 @@ void main() {
         typePassed = type;
       }
 
-      await tester.pumpWidget(
-          LocalizedWidget(child: FeedbackTypeSelection(onPressed: onPressed)));
+      await tester
+          .pumpLocalizedWidget(FeedbackTypeSelection(onPressed: onPressed));
       await tester.pumpAndSettle();
 
       final widget = find.byType(FeedbackTypeSelection);

--- a/test/src/quiz/conclusion/widgets/question_review_tile_test.dart
+++ b/test/src/quiz/conclusion/widgets/question_review_tile_test.dart
@@ -27,8 +27,8 @@ void main() {
           (WidgetTester tester) async {
         question.remainingAttempt = 0;
 
-        await tester.pumpWidget(
-            LocalizedWidget(child: QuestionReviewTile(question: question)));
+        await tester
+            .pumpLocalizedWidget(QuestionReviewTile(question: question));
         await tester.pumpAndSettle();
 
         final widget = find.byType(QuestionReviewTile);
@@ -58,8 +58,8 @@ void main() {
           (WidgetTester tester) async {
         question.remainingAttempt = 1;
 
-        await tester.pumpWidget(
-            LocalizedWidget(child: QuestionReviewTile(question: question)));
+        await tester
+            .pumpLocalizedWidget(QuestionReviewTile(question: question));
         await tester.pumpAndSettle();
 
         final widget = find.byType(QuestionReviewTile);

--- a/test/src/quiz/conclusion/widgets/to_review_section_test.dart
+++ b/test/src/quiz/conclusion/widgets/to_review_section_test.dart
@@ -24,7 +24,8 @@ void main() {
     });
 
     testWidgets("UI", (WidgetTester tester) async {
-      await tester.pumpLocalizedWidget(ToReviewSection(questionsToReview: questions));
+      await tester
+          .pumpLocalizedWidget(ToReviewSection(questionsToReview: questions));
       await tester.pumpAndSettle();
 
       final widget = find.byType(ToReviewSection);

--- a/test/src/quiz/conclusion/widgets/to_review_section_test.dart
+++ b/test/src/quiz/conclusion/widgets/to_review_section_test.dart
@@ -24,8 +24,7 @@ void main() {
     });
 
     testWidgets("UI", (WidgetTester tester) async {
-      await tester.pumpWidget(LocalizedWidget(
-          child: ToReviewSection(questionsToReview: questions)));
+      await tester.pumpLocalizedWidget(ToReviewSection(questionsToReview: questions));
       await tester.pumpAndSettle();
 
       final widget = find.byType(ToReviewSection);

--- a/test/src/quiz/prepare/widgets/group_card_test.dart
+++ b/test/src/quiz/prepare/widgets/group_card_test.dart
@@ -16,11 +16,10 @@ void main() {
 
     group("UI", () {
       testWidgets("Default", (WidgetTester tester) async {
-        await tester.pumpWidget(LocalizedWidget(
-            child: GroupCard(
+        await tester.pumpLocalizedWidget(GroupCard(
           group: groupSample,
           onTap: (Group group) {},
-        )));
+        ));
 
         final widget = find.byType(GroupCard);
 
@@ -41,12 +40,11 @@ void main() {
       });
 
       testWidgets("Checked", (WidgetTester tester) async {
-        await tester.pumpWidget(LocalizedWidget(
-            child: GroupCard(
+        await tester.pumpLocalizedWidget(GroupCard(
           group: groupSample,
           onTap: (Group group) {},
           isChecked: true,
-        )));
+        ));
 
         final widget = find.byType(GroupCard);
 
@@ -67,9 +65,8 @@ void main() {
       });
 
       testWidgets("Localized name", (WidgetTester tester) async {
-        await tester.pumpWidget(LocalizedWidget(
-            child: GroupCard(
-                group: localizedGroupSample, onTap: (Group group) {})));
+        await tester.pumpLocalizedWidget(
+            GroupCard(group: localizedGroupSample, onTap: (Group group) {}));
 
         final widget = find.byType(GroupCard);
 
@@ -91,13 +88,12 @@ void main() {
 
       testWidgets("Tapping on the checkbox should call onTap",
           (WidgetTester tester) async {
-        await tester.pumpWidget(LocalizedWidget(
-            child: GroupCard(
+        await tester.pumpLocalizedWidget(GroupCard(
           group: groupSample,
           onTap: (Group group) {
             log.add(group.id);
           },
-        )));
+        ));
 
         await tester.tap(find.byType(Checkbox));
 
@@ -106,13 +102,12 @@ void main() {
 
       testWidgets("Tapping on the text should call onTap",
           (WidgetTester tester) async {
-        await tester.pumpWidget(LocalizedWidget(
-            child: GroupCard(
+        await tester.pumpLocalizedWidget(GroupCard(
           group: groupSample,
           onTap: (Group group) {
             log.add(group.id);
           },
-        )));
+        ));
 
         await tester.tap(find.text(groupSample.name));
 
@@ -121,13 +116,12 @@ void main() {
 
       testWidgets("Tapping on the card should call onTap",
           (WidgetTester tester) async {
-        await tester.pumpWidget(LocalizedWidget(
-            child: GroupCard(
+        await tester.pumpLocalizedWidget(GroupCard(
           group: groupSample,
           onTap: (Group group) {
             log.add(group.id);
           },
-        )));
+        ));
 
         await tester.tap(find.byType(Card));
 

--- a/test/src/quiz/widgets/animated_dot_test.dart
+++ b/test/src/quiz/widgets/animated_dot_test.dart
@@ -8,8 +8,7 @@ void main() {
   group("AnimatedDot", () {
     testWidgets("Dot should be filled with the default color",
         (WidgetTester tester) async {
-      const widget = AnimatedDot(filledOut: true);
-      await tester.pumpWidget(const LocalizedWidget(child: widget));
+      await tester.pumpLocalizedWidget(const AnimatedDot(filledOut: true));
       await tester.pumpAndSettle();
 
       final found = find.byType(Container);
@@ -26,11 +25,10 @@ void main() {
     testWidgets("Dot should be filled with the passed color",
         (WidgetTester tester) async {
       const color = Colors.red;
-      const widget = AnimatedDot(
+      await tester.pumpLocalizedWidget(const AnimatedDot(
         filledOut: true,
         color: color,
-      );
-      await tester.pumpWidget(const LocalizedWidget(child: widget));
+      ));
       await tester.pumpAndSettle();
 
       final found = find.byType(Container);
@@ -46,8 +44,7 @@ void main() {
 
     testWidgets("Dot should be not filled out with the default color",
         (WidgetTester tester) async {
-      const widget = AnimatedDot(filledOut: false);
-      await tester.pumpWidget(const LocalizedWidget(child: widget));
+      await tester.pumpLocalizedWidget(const AnimatedDot(filledOut: false));
       await tester.pumpAndSettle();
 
       final found = find.byType(Container);

--- a/test/src/quiz/widgets/flip_card_test.dart
+++ b/test/src/quiz/widgets/flip_card_test.dart
@@ -13,7 +13,7 @@ void main() {
         (WidgetTester tester) async {
       const widget = FlipCard(front: Text(frontText), back: Text(rearText));
 
-      await tester.pumpWidget(const LocalizedWidget(child: widget));
+      await tester.pumpLocalizedWidget(widget);
       await tester.pumpAndSettle();
 
       expect(find.text(frontText), findsOneWidget);
@@ -25,7 +25,7 @@ void main() {
       const widget =
           FlipCard(front: Text(frontText), back: Text(rearText), flipped: true);
 
-      await tester.pumpWidget(const LocalizedWidget(child: widget));
+      await tester.pumpLocalizedWidget(widget);
       await tester.pumpAndSettle();
 
       expect(find.text(frontText), findsNothing);
@@ -40,7 +40,7 @@ void main() {
             back: Text(rearText),
             allowTapToFlip: false);
 
-        await tester.pumpWidget(const LocalizedWidget(child: widget));
+        await tester.pumpLocalizedWidget(widget);
         await tester.pumpAndSettle();
 
         expect(find.text(frontText), findsOneWidget);
@@ -58,7 +58,7 @@ void main() {
         const widget = FlipCard(
             front: Text(frontText), back: Text(rearText), allowTapToFlip: true);
 
-        await tester.pumpWidget(const LocalizedWidget(child: widget));
+        await tester.pumpLocalizedWidget(widget);
         await tester.pumpAndSettle();
 
         expect(find.text(frontText), findsOneWidget);

--- a/test/src/settings/widgets/button_item_test.dart
+++ b/test/src/settings/widgets/button_item_test.dart
@@ -10,12 +10,11 @@ void main() {
       const String title = 'TEST';
       int called = 0;
 
-      await tester.pumpWidget(LocalizedWidget(
-          child: ButtonItem(
-              child: const Text(title),
-              onPressed: () {
-                called++;
-              })));
+      await tester.pumpLocalizedWidget(ButtonItem(
+          child: const Text(title),
+          onPressed: () {
+            called++;
+          }));
       await tester.pumpAndSettle();
 
       final widget = find.byType(ButtonItem);

--- a/test/src/settings/widgets/heading_item_test.dart
+++ b/test/src/settings/widgets/heading_item_test.dart
@@ -7,10 +7,9 @@ void main() {
   group("HeadingItem", () {
     testWidgets("UI", (WidgetTester tester) async {
       const String title = 'TEST';
-      await tester.pumpWidget(const LocalizedWidget(
-          child: HeadingItem(
+      await tester.pumpLocalizedWidget(const HeadingItem(
         title: title,
-      )));
+      ));
       await tester.pumpAndSettle();
 
       final widget = find.byType(HeadingItem);

--- a/test/src/settings/widgets/tile_item_test.dart
+++ b/test/src/settings/widgets/tile_item_test.dart
@@ -12,13 +12,12 @@ void main() {
       const IconData leading = Icons.abc;
       const IconData trailing = Icons.account_circle_outlined;
 
-      await tester.pumpWidget(const LocalizedWidget(
-          child: TileItem(
+      await tester.pumpLocalizedWidget(const TileItem(
         title: Text(title),
         subtitle: Text(subtitle),
         leading: Icon(leading),
         trailing: Icon(trailing),
-      )));
+      ));
       await tester.pumpAndSettle();
 
       final widget = find.byType(TileItem);


### PR DESCRIPTION
## 📖 Description
<!--- Describe your changes in detail -->

This PR implements the bottom navigation bar with 5 tabs: home, learn, practice, glossary, and you. Currently, only practice and glossary are enabled.

I modified a little `App` to avoid rebuilding the router whenever we hot-reload the application.

### ⁉️ Related Issues
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--- Please link the issue here: (use keyword `closes: #12345`) -->

closes #92 

<!--- If it's a visual change, please provide a screenshot/video of the changes -->
### 🖼️ Screenshots:
<!--- Use the spoiler system for your screenshots/videos -->

<details>
    <summary>Full application bar</summary> 
    
![Screenshot 2023-11-10 at 5 16 38 PM](https://github.com/RoadTripMoustache/kana_to_kanji/assets/22211097/4a43b2c8-cf42-45ca-9c4f-50abc5937335)

</details>

<details>
    <summary>Current application bar</summary> 
    
![Screenshot 2023-11-10 at 5 19 44 PM](https://github.com/RoadTripMoustache/kana_to_kanji/assets/22211097/66f239fb-ac73-435b-8ceb-875bd7baefbd)

</details>

### 🧪 How to test the change?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your unit test, and the manual tests you did -->
<!--- see how your change affects other areas of the code, etc. -->

1. Open the application
2. Tap on Glossary
3. You should see a simple not found page 

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.