### PR TITLE
feat: Search a kanji, kana, vocabulary in the glossary #98

### DIFF
--- a/lib/src/core/repositories/kana_repository.dart
+++ b/lib/src/core/repositories/kana_repository.dart
@@ -33,10 +33,52 @@ class KanaRepository {
         .toList();
   }
 
+  Future<List<Kana>> searchHiraganaRomaji(String searchTxt) async {
+    await loadKana();
+    if (searchTxt.length > 3) {
+      return Future(() => List.empty());
+    }
+    return _kana
+        .where((element) =>
+            Alphabets.hiragana == element.alphabet &&
+            element.romaji.contains(searchTxt))
+        .toList();
+  }
+
+  Future<List<Kana>> searchHiraganaKana(String searchTxt) async {
+    await loadKana();
+    return _kana
+        .where((element) =>
+            Alphabets.hiragana == element.alphabet &&
+            element.kana.contains(searchTxt))
+        .toList();
+  }
+
   Future<List<Kana>> getKatakana() async {
     await loadKana();
     return _kana
         .where((element) => Alphabets.katakana == element.alphabet)
+        .toList();
+  }
+
+  Future<List<Kana>> searchKatakanaRomaji(String searchTxt) async {
+    await loadKana();
+    if (searchTxt.length > 3) {
+      return Future(() => List.empty());
+    }
+    return _kana
+        .where((element) =>
+            Alphabets.katakana == element.alphabet &&
+            element.romaji.contains(searchTxt))
+        .toList();
+  }
+
+  Future<List<Kana>> searchKatakanaKana(String searchTxt) async {
+    await loadKana();
+    return _kana
+        .where((element) =>
+            Alphabets.katakana == element.alphabet &&
+            element.kana.contains(searchTxt))
         .toList();
   }
 }

--- a/lib/src/core/repositories/kanji_repository.dart
+++ b/lib/src/core/repositories/kanji_repository.dart
@@ -15,4 +15,26 @@ class KanjiRepository {
 
     return kanjis;
   }
+
+  List<Kanji> searchKanjiRomaji(String searchTxt) {
+    return _kanjis
+        .where((kanji) =>
+            kanji.meanings
+                .lastIndexWhere((meaning) => meaning.contains(searchTxt)) >=
+            0)
+        .toList();
+  }
+
+  List<Kanji> searchKanjiJapanese(String searchTxt) {
+    return _kanjis
+        .where((kanji) =>
+            kanji.kanji == searchTxt ||
+            kanji.kunReadings
+                    .lastIndexWhere((reading) => reading.contains(searchTxt)) >=
+                0 ||
+            kanji.onReadings
+                    .lastIndexWhere((reading) => reading.contains(searchTxt)) >=
+                0)
+        .toList();
+  }
 }

--- a/lib/src/core/repositories/vocabulary_repository.dart
+++ b/lib/src/core/repositories/vocabulary_repository.dart
@@ -14,4 +14,22 @@ class VocabularyRepository {
 
     return vocabulary;
   }
+
+  List<Vocabulary> searchVocabularyRomaji(String searchTxt) {
+    return _vocabulary
+        .where((vocabulary) =>
+            vocabulary.romaji.contains(searchTxt) ||
+            vocabulary.meanings
+                    .lastIndexWhere((meaning) => meaning.contains(searchTxt)) >=
+                0)
+        .toList();
+  }
+
+  List<Vocabulary> searchVocabularyJapanese(String searchTxt) {
+    return _vocabulary
+        .where((vocabulary) =>
+            vocabulary.kanji.contains(searchTxt) ||
+            vocabulary.kana.contains(searchTxt))
+        .toList();
+  }
 }

--- a/lib/src/glossary/glossary_view.dart
+++ b/lib/src/glossary/glossary_view.dart
@@ -49,7 +49,7 @@ class _GlossaryViewState extends State<GlossaryView>
                     GlossarySearchBar(searchGlossary: viewModel.searchGlossary),
                 centerTitle: true,
                 backgroundColor: Colors.transparent,
-                toolbarHeight: 64,
+                toolbarHeight: kToolbarHeight,
                 bottom: TabBar.secondary(
                   controller: _tabController,
                   tabs: <Widget>[

--- a/lib/src/glossary/glossary_view.dart
+++ b/lib/src/glossary/glossary_view.dart
@@ -4,6 +4,7 @@ import 'package:kana_to_kanji/src/core/widgets/app_scaffold.dart';
 import 'package:kana_to_kanji/src/glossary/glossary_view_model.dart';
 import 'package:kana_to_kanji/src/glossary/widgets/kana_list.dart';
 import 'package:kana_to_kanji/src/glossary/widgets/kanji_list.dart';
+import 'package:kana_to_kanji/src/glossary/widgets/search_bar.dart';
 import 'package:kana_to_kanji/src/glossary/widgets/vocabulary_list.dart';
 import 'package:stacked/stacked.dart';
 
@@ -42,26 +43,13 @@ class _GlossaryViewState extends State<GlossaryView>
         viewModelBuilder: () => GlossaryViewModel(),
         builder: (context, viewModel, child) {
           return AppScaffold(
-              resizeToAvoidBottomInset: true,
               showBottomBar: true,
               appBar: AppBar(
-                leading: IconButton(
-                  onPressed: () => {},
-                  icon: const Icon(Icons.search),
-                ),
-                title: Text(l10n.glossary_view_title),
-                actions: [
-                  IconButton(
-                    onPressed: () => {},
-                    icon: const Icon(Icons.filter_list_rounded),
-                  ),
-                  IconButton(
-                    onPressed: () => {},
-                    icon: const Icon(Icons.tune),
-                  ),
-                ],
+                title:
+                    GlossarySearchBar(searchGlossary: viewModel.searchGlossary),
                 centerTitle: true,
                 backgroundColor: Colors.transparent,
+                toolbarHeight: 64,
                 bottom: TabBar.secondary(
                   controller: _tabController,
                   tabs: <Widget>[

--- a/lib/src/glossary/glossary_view_model.dart
+++ b/lib/src/glossary/glossary_view_model.dart
@@ -31,15 +31,78 @@ class GlossaryViewModel extends FutureViewModel {
   @override
   Future futureToRun() async {
     final result = await Future.wait([
+      _kanjiRepository.getAll(),
+      _vocabularyRepository.getAll(),
+      _kanaRepository.loadKana()
+    ]);
+
+    _hiraganaList.addAll(await _kanaRepository.getHiragana());
+    _katakanaList.addAll(await _kanaRepository.getKatakana());
+    _kanjiList.addAll(result[0] as List<Kanji>);
+    _vocabularyList.addAll(result[1] as List<Vocabulary>);
+  }
+
+  void searchGlossary(String searchText) async {
+    RegExp alphabeticalRegex = RegExp(r'([a-zA-Z])$');
+    if (searchText == "") {
+      _displayAll();
+    } else if (alphabeticalRegex.hasMatch(searchText)) {
+      _searchLatin(searchText);
+    } else {
+      _searchJapanese(searchText);
+    }
+    notifyListeners();
+  }
+
+  void _searchLatin(String searchText) async {
+    final result = await Future.wait([
+      _kanaRepository.searchHiraganaRomaji(searchText),
+      _kanaRepository.searchKatakanaRomaji(searchText)
+    ]);
+
+    _hiraganaList.clear();
+    _hiraganaList.addAll(result[0]);
+    _katakanaList.clear();
+    _katakanaList.addAll(result[1]);
+    _kanjiList.clear();
+    _kanjiList.addAll(_kanjiRepository.searchKanjiRomaji(searchText));
+    _vocabularyList.clear();
+    _vocabularyList
+        .addAll(_vocabularyRepository.searchVocabularyRomaji(searchText));
+  }
+
+  void _searchJapanese(String searchText) async {
+    final result = await Future.wait([
+      _kanaRepository.searchHiraganaKana(searchText),
+      _kanaRepository.searchKatakanaKana(searchText)
+    ]);
+
+    _hiraganaList.clear();
+    _hiraganaList.addAll(result[0]);
+    _katakanaList.clear();
+    _katakanaList.addAll(result[1]);
+    _kanjiList.clear();
+    _kanjiList.addAll(_kanjiRepository.searchKanjiJapanese(searchText));
+    _vocabularyList.clear();
+    _vocabularyList
+        .addAll(_vocabularyRepository.searchVocabularyJapanese(searchText));
+  }
+
+  void _displayAll() async {
+    final result = await Future.wait([
       _kanaRepository.getHiragana(),
       _kanaRepository.getKatakana(),
       _kanjiRepository.getAll(),
       _vocabularyRepository.getAll()
     ]);
 
+    _hiraganaList.clear();
     _hiraganaList.addAll(result[0] as List<Kana>);
+    _katakanaList.clear();
     _katakanaList.addAll(result[1] as List<Kana>);
+    _kanjiList.clear();
     _kanjiList.addAll(result[2] as List<Kanji>);
+    _vocabularyList.clear();
     _vocabularyList.addAll(result[3] as List<Vocabulary>);
   }
 }

--- a/lib/src/glossary/widgets/search_bar.dart
+++ b/lib/src/glossary/widgets/search_bar.dart
@@ -40,7 +40,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
   bool isOpen = false;
   bool get isInputFilled => _controller.text.isNotEmpty;
   bool isSearchMade = false;
-  double searchBarWidth = 64;
+  double searchBarWidth = kToolbarHeight;
 
   @override
   void initState() {
@@ -62,7 +62,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
 
   double calculateSearchBarWidth() {
     if (!isOpen) {
-      return 64.0;
+      return kToolbarHeight;
     }
     var newWidth = widget.maxWidth;
     if (_focusNode.hasFocus) {
@@ -145,7 +145,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
     return Stack(
       children: [
         SizedBox(
-          height: 64,
+          height: kToolbarHeight,
           child: Row(
             children: [
               Expanded(
@@ -186,7 +186,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
             onTap: cancelSearch,
             child: const SizedBox(
               width: 36,
-              height: 64,
+              height: kToolbarHeight,
               child: Icon(Icons.arrow_back),
             ),
           ),
@@ -200,7 +200,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                   color: color,
                   borderRadius: BorderRadius.circular(borderRadius)),
               width: searchBarWidth,
-              height: 64.0,
+              height: kToolbarHeight,
               alignment: Alignment.center,
               duration: _duration,
               clipBehavior: Clip.hardEdge,
@@ -237,8 +237,8 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                               highlightColor: Colors.transparent,
                               onTap: onTapGlass,
                               child: const SizedBox(
-                                width: 64,
-                                height: 64,
+                                width: kToolbarHeight,
+                                height: kToolbarHeight,
                                 child: Icon(Icons.search),
                               ),
                             )
@@ -253,8 +253,8 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                               highlightColor: Colors.transparent,
                               onTap: clearSearch,
                               child: const SizedBox(
-                                width: 64,
-                                height: 64,
+                                width: kToolbarHeight,
+                                height: kToolbarHeight,
                                 child: Icon(Icons.clear_rounded),
                               ),
                             )

--- a/lib/src/glossary/widgets/search_bar.dart
+++ b/lib/src/glossary/widgets/search_bar.dart
@@ -47,7 +47,6 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
     super.initState();
   }
 
-
   void changeSearchBarAnimationState() {
     setState(() {
       if (isOpen && !_focusNode.hasFocus) {
@@ -233,7 +232,8 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                               key: const Key("glossary_bar_search_icon"),
                               hoverColor: Colors.transparent,
                               splashColor: Colors.transparent,
-                              focusColor: Theme.of(context).colorScheme.secondary,
+                              focusColor:
+                                  Theme.of(context).colorScheme.secondary,
                               highlightColor: Colors.transparent,
                               onTap: onTapGlass,
                               child: const SizedBox(
@@ -248,7 +248,8 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                               key: const Key("glossary_bar_clear_search_icon"),
                               hoverColor: Colors.transparent,
                               splashColor: Colors.transparent,
-                              focusColor: Theme.of(context).colorScheme.secondary,
+                              focusColor:
+                                  Theme.of(context).colorScheme.secondary,
                               highlightColor: Colors.transparent,
                               onTap: clearSearch,
                               child: const SizedBox(

--- a/lib/src/glossary/widgets/search_bar.dart
+++ b/lib/src/glossary/widgets/search_bar.dart
@@ -179,8 +179,9 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
         if (isOpen && isSearchMade)
           InkWell(
             key: const Key("glossary_bar_cancel_search_icon"),
-            hoverColor: Colors.transparent,
-            splashColor: Colors.transparent,
+            borderRadius: BorderRadius.circular(25),
+            hoverColor: Theme.of(context).colorScheme.secondary,
+            splashColor: Theme.of(context).colorScheme.secondary,
             focusColor: Theme.of(context).colorScheme.secondary,
             highlightColor: Colors.transparent,
             onTap: cancelSearch,
@@ -200,7 +201,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                   color: color,
                   borderRadius: BorderRadius.circular(borderRadius)),
               width: searchBarWidth,
-              height: kToolbarHeight,
+              height: kToolbarHeight-2,
               alignment: Alignment.center,
               duration: _duration,
               clipBehavior: Clip.hardEdge,
@@ -230,8 +231,9 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                       prefixIcon: !isSearchMade
                           ? InkWell(
                               key: const Key("glossary_bar_search_icon"),
-                              hoverColor: Colors.transparent,
-                              splashColor: Colors.transparent,
+                              borderRadius: BorderRadius.circular(25),
+                              hoverColor: Theme.of(context).colorScheme.secondary,
+                              splashColor: Theme.of(context).colorScheme.secondary,
                               focusColor:
                                   Theme.of(context).colorScheme.secondary,
                               highlightColor: Colors.transparent,
@@ -246,8 +248,9 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                       suffixIcon: isInputFilled
                           ? InkWell(
                               key: const Key("glossary_bar_clear_search_icon"),
-                              hoverColor: Colors.transparent,
-                              splashColor: Colors.transparent,
+                              borderRadius: BorderRadius.circular(25),
+                              hoverColor: Theme.of(context).colorScheme.secondary,
+                              splashColor: Theme.of(context).colorScheme.secondary,
                               focusColor:
                                   Theme.of(context).colorScheme.secondary,
                               highlightColor: Colors.transparent,

--- a/lib/src/glossary/widgets/search_bar.dart
+++ b/lib/src/glossary/widgets/search_bar.dart
@@ -1,0 +1,265 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+const _duration = Duration(milliseconds: 400);
+
+class GlossarySearchBar extends StatelessWidget {
+  final void Function(String searchText) searchGlossary;
+
+  const GlossarySearchBar({super.key, required this.searchGlossary});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return GlossarySearchBarContent(
+            maxWidth: constraints.maxWidth, searchGlossary: searchGlossary);
+      },
+    );
+  }
+}
+
+class GlossarySearchBarContent extends StatefulWidget {
+  final double maxWidth;
+  final void Function(String searchText) searchGlossary;
+
+  const GlossarySearchBarContent(
+      {super.key, required this.maxWidth, required this.searchGlossary});
+
+  @override
+  State<GlossarySearchBarContent> createState() => _GlossarySearchBarState();
+}
+
+class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
+  final TextEditingController _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
+
+  Color color = Colors.transparent;
+  double borderRadius = 32;
+  double margin = 1;
+  bool isOpen = false;
+  bool get isInputFilled => _controller.text.isNotEmpty;
+  bool isSearchMade = false;
+  double searchBarWidth = 64;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+
+  void changeSearchBarAnimationState() {
+    setState(() {
+      if (isOpen && !_focusNode.hasFocus) {
+        color = Theme.of(context).colorScheme.inversePrimary;
+      } else if (isOpen && _focusNode.hasFocus) {
+        color = Theme.of(context).colorScheme.inversePrimary;
+      } else {
+        color = Colors.transparent;
+      }
+      searchBarWidth = calculateSearchBarWidth();
+    });
+  }
+
+  double calculateSearchBarWidth() {
+    if (!isOpen) {
+      return 64.0;
+    }
+    var newWidth = widget.maxWidth;
+    if (_focusNode.hasFocus) {
+      newWidth = newWidth - 94.0;
+    }
+    if (isSearchMade) {
+      newWidth = newWidth - 40;
+    }
+    return newWidth;
+  }
+
+  /// Event trigger when the glass icon is tapped.
+  /// - Open the search bar if closed
+  /// - Close the search bar if the input is empty
+  /// - Trigger a search if the input is not empty
+  void onTapGlass() {
+    if (!isOpen) {
+      isOpen = true;
+      _focusNode.requestFocus();
+    } else if (_controller.text.isEmpty) {
+      isOpen = false;
+      _focusNode.unfocus();
+      widget.searchGlossary("");
+    } else {
+      isSearchMade = true;
+      _focusNode.unfocus();
+      onSubmit(_controller.text);
+    }
+    changeSearchBarAnimationState();
+  }
+
+  void clearSearch() {
+    _controller.clear();
+    isSearchMade = false;
+    _focusNode.unfocus();
+    _focusNode.requestFocus();
+    focusInSearch();
+  }
+
+  void focusOutSearch(event) {
+    _focusNode.unfocus();
+    changeSearchBarAnimationState();
+  }
+
+  void focusInSearch() {
+    _focusNode.requestFocus();
+    changeSearchBarAnimationState();
+  }
+
+  void cancelSearch() {
+    isSearchMade = false;
+    clearSearch();
+    focusOutSearch(null);
+    isOpen = false;
+    changeSearchBarAnimationState();
+    widget.searchGlossary("");
+  }
+
+  void onSubmit(String searchTxt) {
+    if (searchTxt != "") {
+      isSearchMade = true;
+      focusOutSearch(null);
+      widget.searchGlossary(searchTxt);
+    } else {
+      _focusNode.requestFocus();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context);
+
+    return Stack(
+      children: [
+        SizedBox(
+          height: 64,
+          child: Row(
+            children: [
+              Expanded(
+                flex: 1,
+                child: Container(),
+              ),
+              Expanded(
+                flex: 2,
+                child: Center(
+                  child: Text(l10n.glossary_view_title),
+                ),
+              ),
+              Expanded(
+                  flex: 1,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      IconButton(
+                        onPressed: () => {},
+                        icon: const Icon(Icons.filter_list_rounded),
+                      ),
+                      IconButton(
+                        onPressed: () => {},
+                        icon: const Icon(Icons.tune),
+                      ),
+                    ],
+                  )),
+            ],
+          ),
+        ),
+        if (isOpen && isSearchMade)
+          InkWell(
+            key: const Key("glossary_bar_cancel_search_icon"),
+            hoverColor: Colors.transparent,
+            splashColor: Colors.transparent,
+            focusColor: Theme.of(context).colorScheme.secondary,
+            highlightColor: Colors.transparent,
+            onTap: cancelSearch,
+            child: const SizedBox(
+              width: 36,
+              height: 64,
+              child: Icon(Icons.arrow_back),
+            ),
+          ),
+        AnimatedPositioned(
+          width: searchBarWidth,
+          duration: _duration,
+          left: isSearchMade ? 36 : 0,
+          child: AnimatedContainer(
+              margin: EdgeInsets.all(margin),
+              decoration: BoxDecoration(
+                  color: color,
+                  borderRadius: BorderRadius.circular(borderRadius)),
+              width: searchBarWidth,
+              height: 64.0,
+              alignment: Alignment.center,
+              duration: _duration,
+              clipBehavior: Clip.hardEdge,
+              child: TextField(
+                  key: const Key("glossary_bar_search_text_field"),
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  autocorrect: false,
+                  autofocus: false,
+                  textAlign: TextAlign.left,
+                  textAlignVertical: TextAlignVertical.center,
+                  textInputAction: TextInputAction.send,
+                  onTapOutside: focusOutSearch,
+                  onTap: focusInSearch,
+                  onSubmitted: onSubmit,
+                  decoration: InputDecoration(
+                      border: InputBorder.none,
+                      focusedBorder: InputBorder.none,
+                      enabledBorder: InputBorder.none,
+                      disabledBorder: InputBorder.none,
+                      hintText: isOpen ? l10n.glossary_search_bar_hint : "",
+                      hintStyle:
+                          const TextStyle(decoration: TextDecoration.none),
+                      fillColor: Colors.transparent,
+                      contentPadding:
+                          const EdgeInsets.symmetric(horizontal: 20),
+                      prefixIcon: !isSearchMade
+                          ? InkWell(
+                              key: const Key("glossary_bar_search_icon"),
+                              hoverColor: Colors.transparent,
+                              splashColor: Colors.transparent,
+                              focusColor: Theme.of(context).colorScheme.secondary,
+                              highlightColor: Colors.transparent,
+                              onTap: onTapGlass,
+                              child: const SizedBox(
+                                width: 64,
+                                height: 64,
+                                child: Icon(Icons.search),
+                              ),
+                            )
+                          : null,
+                      suffixIcon: isInputFilled
+                          ? InkWell(
+                              key: const Key("glossary_bar_clear_search_icon"),
+                              hoverColor: Colors.transparent,
+                              splashColor: Colors.transparent,
+                              focusColor: Theme.of(context).colorScheme.secondary,
+                              highlightColor: Colors.transparent,
+                              onTap: clearSearch,
+                              child: const SizedBox(
+                                width: 64,
+                                height: 64,
+                                child: Icon(Icons.clear_rounded),
+                              ),
+                            )
+                          : null))),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/glossary/widgets/search_bar.dart
+++ b/lib/src/glossary/widgets/search_bar.dart
@@ -201,7 +201,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                   color: color,
                   borderRadius: BorderRadius.circular(borderRadius)),
               width: searchBarWidth,
-              height: kToolbarHeight-2,
+              height: kToolbarHeight - 2,
               alignment: Alignment.center,
               duration: _duration,
               clipBehavior: Clip.hardEdge,
@@ -232,8 +232,10 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                           ? InkWell(
                               key: const Key("glossary_bar_search_icon"),
                               borderRadius: BorderRadius.circular(25),
-                              hoverColor: Theme.of(context).colorScheme.secondary,
-                              splashColor: Theme.of(context).colorScheme.secondary,
+                              hoverColor:
+                                  Theme.of(context).colorScheme.secondary,
+                              splashColor:
+                                  Theme.of(context).colorScheme.secondary,
                               focusColor:
                                   Theme.of(context).colorScheme.secondary,
                               highlightColor: Colors.transparent,
@@ -249,8 +251,10 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                           ? InkWell(
                               key: const Key("glossary_bar_clear_search_icon"),
                               borderRadius: BorderRadius.circular(25),
-                              hoverColor: Theme.of(context).colorScheme.secondary,
-                              splashColor: Theme.of(context).colorScheme.secondary,
+                              hoverColor:
+                                  Theme.of(context).colorScheme.secondary,
+                              splashColor:
+                                  Theme.of(context).colorScheme.secondary,
                               focusColor:
                                   Theme.of(context).colorScheme.secondary,
                               highlightColor: Colors.transparent,

--- a/localization/en.arb
+++ b/localization/en.arb
@@ -232,5 +232,6 @@
   "glossary_tab_vocabulary": "Vocabulary",
   "glossary_tab_hiragana": "Hiragana",
   "glossary_tab_katakana": "Katakana",
-  "glossary_tab_kanji": "Kanji"
+  "glossary_tab_kanji": "Kanji",
+  "glossary_search_bar_hint": "日本, にほん, Japan"
 }

--- a/localization/fr.arb
+++ b/localization/fr.arb
@@ -227,5 +227,6 @@
   "glossary_tab_vocabulary": "Vocabulaire",
   "glossary_tab_hiragana": "Hiragana",
   "glossary_tab_katakana": "Katakana",
-  "glossary_tab_kanji": "Kanji"
+  "glossary_tab_kanji": "Kanji",
+  "glossary_search_bar_hint": "日本, にほん, Japon"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.12.0+1
+version: 0.13.0+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/test/src/glossary/widgets/search_bar_test.dart
+++ b/test/src/glossary/widgets/search_bar_test.dart
@@ -1,0 +1,412 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kana_to_kanji/src/glossary/widgets/search_bar.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../../../helpers.dart';
+
+void main() {
+  group("GlossarySearchBar", () {
+    testWidgets("Default view", (WidgetTester tester) async {
+      /**
+       * Steps:
+       * 1. Load the GlossarySearchBar
+       */
+
+      await tester.pumpLocalizedWidget(GlossarySearchBar(
+        searchGlossary: (String searchText) => {},
+      ));
+      await tester.pumpAndSettle();
+
+      final searchBar = find.byType(GlossarySearchBar);
+      expect(searchBar, findsOneWidget);
+
+      final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+      expect(searchIcon, findsOneWidget);
+
+      checkClosedState(tester);
+    });
+
+    testWidgets("Open search bar", (WidgetTester tester) async {
+      /**
+       * Steps:
+       * 1. Load the GlossarySearchBar
+       * 2. Open the search bar
+       */
+
+      final l10n = await setupLocalizations();
+
+      await tester.pumpLocalizedWidget(GlossarySearchBar(
+        searchGlossary: (String searchText) => {},
+      ));
+
+      // Simulate click to open the search bar
+      final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      final searchTextField =
+          find.byKey(const Key("glossary_bar_search_text_field"));
+      expect(
+          tester.widget(searchTextField),
+          isA<TextField>().having((tf) => tf.decoration?.hintText,
+              "decoration.hintText", l10n.glossary_search_bar_hint));
+
+      final found = find.byType(GlossarySearchBar);
+      expect(found, findsOneWidget);
+    });
+
+    testWidgets("Open/Close search bar", (WidgetTester tester) async {
+      /**
+       * Steps:
+       * 1. Load the GlossarySearchBar
+       * 2. Open the search bar
+       * 3. Close the search bar by clicking on the `search` icon
+       */
+      // Init widget
+      final l10n = await setupLocalizations();
+
+      await tester.pumpLocalizedWidget(GlossarySearchBar(
+        searchGlossary: (String searchText) => {},
+      ));
+
+      // Simulate click to open the search bar
+      final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithoutTextState(tester, l10n);
+
+      // Simulate click to close the search bar
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkClosedState(tester);
+    });
+
+    testWidgets("Tap text in search bar", (WidgetTester tester) async {
+      /**
+       * Steps:
+       * 1. Load the GlossarySearchBar
+       * 2. Open the search bar
+       * 3. Tap text in the search bar
+       */
+      // Init widget
+      final l10n = await setupLocalizations();
+
+      await tester.pumpLocalizedWidget(GlossarySearchBar(
+        searchGlossary: (String searchText) => {},
+      ));
+
+      // Simulate click to open the search bar
+      final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithoutTextState(tester, l10n);
+
+      // Simulate text typed in search field
+      final searchTextField =
+          find.byKey(const Key("glossary_bar_search_text_field"));
+      await tester.enterText(searchTextField, "toto");
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithTextState(tester, "toto", false);
+    });
+
+    testWidgets("Search text", (WidgetTester tester) async {
+      /**
+       * Steps:
+       * 1. Load the GlossarySearchBar
+       * 2. Open the search bar
+       * 3. Tap text in the search bar
+       * 4. Trigger search
+       */
+      // Init widget
+      final l10n = await setupLocalizations();
+
+      await tester.pumpLocalizedWidget(GlossarySearchBar(
+        searchGlossary: (String searchText) => {},
+      ));
+
+      // Simulate click to open the search bar
+      final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithoutTextState(tester, l10n);
+
+      // Simulate text typed in search field
+      final searchTextField =
+          find.byKey(const Key("glossary_bar_search_text_field"));
+      await tester.enterText(searchTextField, "toto");
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithTextState(tester, "toto", false);
+
+      // Simulate click to trigger the search
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkSearchState(tester, "toto");
+    });
+
+    testWidgets("Search text, then clear", (WidgetTester tester) async {
+      /**
+       * Steps:
+       * 1. Load the GlossarySearchBar
+       * 2. Open the search bar
+       * 3. Tap text in the search bar
+       * 4. Trigger search
+       * 5. Clear text input
+       */
+      // Init widget
+      final l10n = await setupLocalizations();
+
+      await tester.pumpLocalizedWidget(GlossarySearchBar(
+        searchGlossary: (String searchText) => {},
+      ));
+
+      // Simulate click to open the search bar
+      final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithoutTextState(tester, l10n);
+
+      // Simulate text typed in search field
+      final searchTextField =
+          find.byKey(const Key("glossary_bar_search_text_field"));
+      await tester.enterText(searchTextField, "toto");
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithTextState(tester, "toto", false);
+
+      // Simulate click to trigger the search
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkSearchState(tester, "toto");
+
+      // Simulate click to clear the input
+      final clearSearchIcon =
+          find.byKey(const Key("glossary_bar_clear_search_icon"));
+      await tester.tap(clearSearchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithoutTextState(tester, l10n);
+    });
+
+    testWidgets("Search text, then clear and close",
+        (WidgetTester tester) async {
+      /**
+       * Steps:
+       * 1. Load the GlossarySearchBar
+       * 2. Open the search bar
+       * 3. Tap text in the search bar
+       * 4. Trigger search
+       * 5. Clear text input
+       * 6. Close search bar with the search icon
+       */
+      // Init widget
+      final l10n = await setupLocalizations();
+
+      await tester.pumpLocalizedWidget(GlossarySearchBar(
+        searchGlossary: (String searchText) => {},
+      ));
+
+      // Simulate click to open the search bar
+      final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithoutTextState(tester, l10n);
+
+      // Simulate text typed in search field
+      final searchTextField =
+          find.byKey(const Key("glossary_bar_search_text_field"));
+      await tester.enterText(searchTextField, "toto");
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithTextState(tester, "toto", false);
+
+      // Simulate click to trigger the search
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkSearchState(tester, "toto");
+
+      // Simulate click to clear the input
+      final clearSearchIcon =
+          find.byKey(const Key("glossary_bar_clear_search_icon"));
+      await tester.tap(clearSearchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithoutTextState(tester, l10n);
+
+      // Simulate click to close the search bar
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkClosedState(tester);
+    });
+
+    testWidgets("Search text, then close", (WidgetTester tester) async {
+      /**
+       * Steps:
+       * 1. Load the GlossarySearchBar
+       * 2. Open the search bar
+       * 3. Tap text in the search bar
+       * 4. Trigger search
+       * 5. Close search bar with the arrow
+       */
+      // Init widget
+      final l10n = await setupLocalizations();
+
+      await tester.pumpLocalizedWidget(GlossarySearchBar(
+        searchGlossary: (String searchText) => {},
+      ));
+
+      // Simulate click to open the search bar
+      final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithoutTextState(tester, l10n);
+
+      // Simulate text typed in search field
+      final searchTextField =
+          find.byKey(const Key("glossary_bar_search_text_field"));
+      await tester.enterText(searchTextField, "toto");
+
+      await tester.pumpAndSettle();
+
+      checkOpenWithTextState(tester, "toto", false);
+
+      // Simulate click to trigger the search
+      await tester.tap(searchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkSearchState(tester, "toto");
+
+      // Simulate click to clear the input
+      final cancelSearchIcon =
+          find.byKey(const Key("glossary_bar_cancel_search_icon"));
+      await tester.tap(cancelSearchIcon);
+
+      await tester.pumpAndSettle();
+
+      checkClosedState(tester);
+    });
+  });
+}
+
+// Check components of the search bar when the search bar is closed.
+void checkClosedState(WidgetTester tester) {
+  final searchTextField =
+      find.byKey(const Key("glossary_bar_search_text_field"));
+  expect(
+      tester.widget(searchTextField),
+      isA<TextField>()
+          .having((tf) => tf.decoration?.hintText, "decoration.hintText", ""));
+
+  final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+  expect(searchIcon, findsOneWidget);
+
+  final clearSearchIcon =
+      find.byKey(const Key("glossary_bar_clear_search_icon"));
+  expect(clearSearchIcon, findsNothing);
+
+  final closeSearchIcon =
+      find.byKey(const Key("glossary_bar_cancel_search_icon"));
+  expect(closeSearchIcon, findsNothing);
+}
+
+// Check components of the search bar when the search bar is opened and no text is typed in the input.
+void checkOpenWithoutTextState(WidgetTester tester, AppLocalizations l10n) {
+  final searchTextField =
+      find.byKey(const Key("glossary_bar_search_text_field"));
+  expect(
+      tester.widget(searchTextField),
+      isA<TextField>().having((tf) => tf.decoration?.hintText,
+          "decoration.hintText", l10n.glossary_search_bar_hint));
+  expect((tester.widget(searchTextField) as TextField).focusNode?.hasFocus,
+      isTrue);
+
+  final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+  expect(searchIcon, findsOneWidget);
+
+  final clearSearchIcon =
+      find.byKey(const Key("glossary_bar_clear_search_icon"));
+  expect(clearSearchIcon, findsNothing);
+
+  final closeSearchIcon =
+      find.byKey(const Key("glossary_bar_cancel_search_icon"));
+  expect(closeSearchIcon, findsNothing);
+}
+
+// Check components of the search bar when the search bar is opened and text is typed in the input.
+void checkOpenWithTextState(
+    WidgetTester tester, String textSearchInput, bool isClearVisible) {
+  final searchTextField =
+      find.byKey(const Key("glossary_bar_search_text_field"));
+  expect(
+      tester.widget(searchTextField),
+      isA<TextField>().having(
+          (tf) => tf.controller?.text, "controller.test", textSearchInput));
+  expect((tester.widget(searchTextField) as TextField).focusNode?.hasFocus,
+      isTrue);
+
+  final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+  expect(searchIcon, findsOneWidget);
+
+  final clearSearchIcon =
+      find.byKey(const Key("glossary_bar_clear_search_icon"));
+  expect(clearSearchIcon, (isClearVisible ? findsOneWidget : findsNothing));
+
+  final closeSearchIcon =
+      find.byKey(const Key("glossary_bar_cancel_search_icon"));
+  expect(closeSearchIcon, findsNothing);
+}
+
+// Check components of the search bar when a search has been triggered.
+void checkSearchState(WidgetTester tester, String textSearchInput) {
+  final searchTextField =
+      find.byKey(const Key("glossary_bar_search_text_field"));
+  expect(
+      tester.widget(searchTextField),
+      isA<TextField>().having(
+          (tf) => tf.controller?.text, "controller.test", textSearchInput));
+  expect((tester.widget(searchTextField) as TextField).focusNode?.hasFocus,
+      isFalse);
+
+  final searchIcon = find.byKey(const Key("glossary_bar_search_icon"));
+  expect(searchIcon, findsNothing);
+
+  final clearSearchIcon =
+      find.byKey(const Key("glossary_bar_clear_search_icon"));
+  expect(clearSearchIcon, findsOneWidget);
+
+  final closeSearchIcon =
+      find.byKey(const Key("glossary_bar_cancel_search_icon"));
+  expect(closeSearchIcon, findsOneWidget);
+}


### PR DESCRIPTION
## 📖 Description
Add a search bar in the glossary section.

### ⁉️ Related Issues
closes: #98

### 🖼️ Screenshots:
<!--- Use the spoiler system for your screenshots/videos -->

<details>
    <summary>App bar opened</summary> 
    
![Screenshot_20231202_075302](https://github.com/RoadTripMoustache/kana_to_kanji/assets/36586573/9c8feaa8-fde5-4661-b59f-02ee65f15ca7)

</details>

<details>
    <summary>App bar with a search made</summary> 
    
![Screenshot_20231202_075334](https://github.com/RoadTripMoustache/kana_to_kanji/assets/36586573/cf8803b7-e302-4205-b439-b907cf172d4c)

</details>

### 🧪 How to test the change?
1. Open the app
2. Go to the "Glossary" 
3. Use the search bar by clicking on the "search" icon

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.