### PR TITLE
fix: Do the update to be able to use the latest version of the api

### DIFF
--- a/lib/src/core/dataloaders/kanji_dataloader.dart
+++ b/lib/src/core/dataloaders/kanji_dataloader.dart
@@ -31,11 +31,23 @@ class KanjiDataLoader {
     if (response.statusCode == 200) {
       List<Kanji> kanjis = [];
       var listKanji = jsonDecode(response.body);
-      for (final k in listKanji) {
-        if (k["kun_readings"][0] != "") {
+      for (final k in listKanji["data"]) {
+        if (k["meanings"] == null) { // TODO : To delete once "meanings" is not used anymore
+          k["meanings"] = ["toto"];
+        }
+        if (k["on_readings"] == null) { // TODO : To delete once "on_readings" is not used anymore
+          k["on_readings"] = ["ア"];
+        }
+        if (k["kun_readings"] == null) { // TODO : To delete once "on_readings" is not used anymore
+          k["kun_readings"] = ["あ"];
+        }
+        k["jp_sort_syllables"] = [];
+        if (k["kun_readings"] != null && !k["kun_readings"].isEmpty && k["kun_readings"][0] != "") {
           k["jp_sort_syllables"] = splitBySyllable(k["kun_readings"][0]);
-        } else {
+        } else if (k["on_readings"] != null && !k["on_readings"].isEmpty){
           k["jp_sort_syllables"] = splitBySyllable(k["on_readings"][0]);
+        } else if (k["pronunciations"] != null && !k["pronunciations"].isEmpty){
+          k["jp_sort_syllables"] = splitBySyllable(k["pronunciations"][0]["readings"][0]);
         }
         kanjis.add(Kanji.fromJson(k));
       }

--- a/lib/src/core/dataloaders/kanji_dataloader.dart
+++ b/lib/src/core/dataloaders/kanji_dataloader.dart
@@ -32,22 +32,29 @@ class KanjiDataLoader {
       List<Kanji> kanjis = [];
       var listKanji = jsonDecode(response.body);
       for (final k in listKanji["data"]) {
-        if (k["meanings"] == null) { // TODO : To delete once "meanings" is not used anymore
+        if (k["meanings"] == null) {
+          // TODO : To delete once "meanings" is not used anymore
           k["meanings"] = ["toto"];
         }
-        if (k["on_readings"] == null) { // TODO : To delete once "on_readings" is not used anymore
+        if (k["on_readings"] == null) {
+          // TODO : To delete once "on_readings" is not used anymore
           k["on_readings"] = ["ア"];
         }
-        if (k["kun_readings"] == null) { // TODO : To delete once "on_readings" is not used anymore
+        if (k["kun_readings"] == null) {
+          // TODO : To delete once "on_readings" is not used anymore
           k["kun_readings"] = ["あ"];
         }
         k["jp_sort_syllables"] = [];
-        if (k["kun_readings"] != null && !k["kun_readings"].isEmpty && k["kun_readings"][0] != "") {
+        if (k["kun_readings"] != null &&
+            !k["kun_readings"].isEmpty &&
+            k["kun_readings"][0] != "") {
           k["jp_sort_syllables"] = splitBySyllable(k["kun_readings"][0]);
-        } else if (k["on_readings"] != null && !k["on_readings"].isEmpty){
+        } else if (k["on_readings"] != null && !k["on_readings"].isEmpty) {
           k["jp_sort_syllables"] = splitBySyllable(k["on_readings"][0]);
-        } else if (k["pronunciations"] != null && !k["pronunciations"].isEmpty){
-          k["jp_sort_syllables"] = splitBySyllable(k["pronunciations"][0]["readings"][0]);
+        } else if (k["pronunciations"] != null &&
+            !k["pronunciations"].isEmpty) {
+          k["jp_sort_syllables"] =
+              splitBySyllable(k["pronunciations"][0]["readings"][0]);
         }
         kanjis.add(Kanji.fromJson(k));
       }

--- a/lib/src/core/dataloaders/vocabulary_dataloader.dart
+++ b/lib/src/core/dataloaders/vocabulary_dataloader.dart
@@ -31,7 +31,11 @@ class VocabularyDataLoader {
     if (response.statusCode == 200) {
       List<Vocabulary> vocabulary = [];
       var listVocabulary = jsonDecode(response.body);
-      for (final k in listVocabulary) {
+      for (final k in listVocabulary["data"]) {
+        if (k["meanings"] == null) { // TODO : Delete once "meanings" is not used anymore
+          k["meanings"] = ["toto"];
+        }
+
         k["kana_syllables"] = splitBySyllable(k["kana"]);
         vocabulary.add(Vocabulary.fromJson(k));
       }

--- a/lib/src/core/dataloaders/vocabulary_dataloader.dart
+++ b/lib/src/core/dataloaders/vocabulary_dataloader.dart
@@ -32,7 +32,8 @@ class VocabularyDataLoader {
       List<Vocabulary> vocabulary = [];
       var listVocabulary = jsonDecode(response.body);
       for (final k in listVocabulary["data"]) {
-        if (k["meanings"] == null) { // TODO : Delete once "meanings" is not used anymore
+        if (k["meanings"] == null) {
+          // TODO : Delete once "meanings" is not used anymore
           k["meanings"] = ["toto"];
         }
 

--- a/lib/src/core/models/kanji.dart
+++ b/lib/src/core/models/kanji.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:isar/isar.dart';
+import 'package:kana_to_kanji/src/core/models/pronunciations.dart';
 
 part 'kanji.g.dart';
 
@@ -25,18 +26,28 @@ class Kanji {
   /// Pronunciations in sino-Japanese
   @Default([])
   @JsonKey(name: "on_readings")
-  final List<String> onReadings;
+  final List<String> onReadings; // TODO : To delete once migrated to "pronunciations"
 
   /// Pronunciations in Japanese
   @Default([])
   @JsonKey(name: "kun_readings")
-  final List<String> kunReadings;
+  final List<String> kunReadings; // TODO : To delete once migrated to "pronunciations"
+
+  /// Pronunciations of the kanji
+  @Default([])
+  final List<Pronunciation> pronunciations;
+
   final String version;
 
   /// List of vocabulary word ids that use the kanji
   @Default([])
   @JsonKey(name: "vocabulary_ids")
-  final List<int>? vocabularyIds;
+  final List<int>? vocabularyIds; // TODO : To delete once migrated to "relatedVocabulary"
+
+  /// List of vocabulary words that use the kanji
+  @Default([])
+  @JsonKey(name: "related_vocabulary")
+  final List<int>? relatedVocabulary;
 
   /// List of syllables of the first kanji Kun reading to facilitate the kanji sorting
   @JsonKey(name: "jp_sort_syllables")
@@ -51,8 +62,10 @@ class Kanji {
       this.meanings,
       this.onReadings,
       this.kunReadings,
+      this.pronunciations,
       this.version,
       this.vocabularyIds,
+      this.relatedVocabulary,
       this.jpSortSyllables);
 
   factory Kanji.fromJson(Map<String, dynamic> json) => _$KanjiFromJson(json);

--- a/lib/src/core/models/kanji.dart
+++ b/lib/src/core/models/kanji.dart
@@ -26,12 +26,14 @@ class Kanji {
   /// Pronunciations in sino-Japanese
   @Default([])
   @JsonKey(name: "on_readings")
-  final List<String> onReadings; // TODO : To delete once migrated to "pronunciations"
+  final List<String>
+      onReadings; // TODO : To delete once migrated to "pronunciations"
 
   /// Pronunciations in Japanese
   @Default([])
   @JsonKey(name: "kun_readings")
-  final List<String> kunReadings; // TODO : To delete once migrated to "pronunciations"
+  final List<String>
+      kunReadings; // TODO : To delete once migrated to "pronunciations"
 
   /// Pronunciations of the kanji
   @Default([])
@@ -42,7 +44,8 @@ class Kanji {
   /// List of vocabulary word ids that use the kanji
   @Default([])
   @JsonKey(name: "vocabulary_ids")
-  final List<int>? vocabularyIds; // TODO : To delete once migrated to "relatedVocabulary"
+  final List<int>?
+      vocabularyIds; // TODO : To delete once migrated to "relatedVocabulary"
 
   /// List of vocabulary words that use the kanji
   @Default([])

--- a/lib/src/core/models/kanji_reading.dart
+++ b/lib/src/core/models/kanji_reading.dart
@@ -8,6 +8,7 @@ part 'kanji_reading.g.dart';
 
 /// Reading of a kanji in a word.
 class KanjiReading {
+  /// ID of the kanji
   final int id;
   final String kanji;
   final String reading;

--- a/lib/src/core/models/kanji_reading.dart
+++ b/lib/src/core/models/kanji_reading.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:isar/isar.dart';
+
+part 'kanji_reading.g.dart';
+
+@JsonSerializable()
+@embedded
+/// Reading of a kanji in a word.
+class KanjiReading {
+  final int id;
+  final String kanji;
+  final String reading;
+
+
+  const KanjiReading(
+      this.id,
+      this.kanji,
+      this.reading);
+
+  factory KanjiReading.fromJson(Map<String, dynamic> json) => _$KanjiReadingFromJson(json);
+}

--- a/lib/src/core/models/kanji_reading.dart
+++ b/lib/src/core/models/kanji_reading.dart
@@ -5,17 +5,15 @@ part 'kanji_reading.g.dart';
 
 @JsonSerializable()
 @embedded
+
 /// Reading of a kanji in a word.
 class KanjiReading {
   final int id;
   final String kanji;
   final String reading;
 
+  const KanjiReading(this.id, this.kanji, this.reading);
 
-  const KanjiReading(
-      this.id,
-      this.kanji,
-      this.reading);
-
-  factory KanjiReading.fromJson(Map<String, dynamic> json) => _$KanjiReadingFromJson(json);
+  factory KanjiReading.fromJson(Map<String, dynamic> json) =>
+      _$KanjiReadingFromJson(json);
 }

--- a/lib/src/core/models/pronunciations.dart
+++ b/lib/src/core/models/pronunciations.dart
@@ -5,6 +5,7 @@ part 'pronunciations.g.dart';
 
 @JsonSerializable()
 @embedded
+
 /// Pronunciation of a kanji with all the meanings matching the readings
 class Pronunciation {
   final int index;
@@ -13,11 +14,8 @@ class Pronunciation {
   @Default([])
   final List<String> readings;
 
+  const Pronunciation(this.index, this.meanings, this.readings);
 
-  const Pronunciation(
-      this.index,
-      this.meanings,
-      this.readings);
-
-  factory Pronunciation.fromJson(Map<String, dynamic> json) => _$PronunciationFromJson(json);
+  factory Pronunciation.fromJson(Map<String, dynamic> json) =>
+      _$PronunciationFromJson(json);
 }

--- a/lib/src/core/models/pronunciations.dart
+++ b/lib/src/core/models/pronunciations.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:isar/isar.dart';
+
+part 'pronunciations.g.dart';
+
+@JsonSerializable()
+@embedded
+/// Pronunciation of a kanji with all the meanings matching the readings
+class Pronunciation {
+  final int index;
+  @Default([])
+  final List<String> meanings;
+  @Default([])
+  final List<String> readings;
+
+
+  const Pronunciation(
+      this.index,
+      this.meanings,
+      this.readings);
+
+  factory Pronunciation.fromJson(Map<String, dynamic> json) => _$PronunciationFromJson(json);
+}

--- a/lib/src/core/models/vocabulary.dart
+++ b/lib/src/core/models/vocabulary.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:isar/isar.dart';
+import 'package:kana_to_kanji/src/core/models/kanji_reading.dart';
 
 part 'vocabulary.g.dart';
 
@@ -31,7 +32,13 @@ class Vocabulary {
 
   /// List of syllables forming the word in kana. Use to facilitate vocabulary sorting.
   @JsonKey(name: "kana_syllables")
-  final List<String> kanaSyllables;
+  final List<String> kanaSyllables; // TODO: To remove once migrated to "kanjiReadings"
+
+  /// List of kanji which are in the vocabulary with their respective reading
+  @Default([])
+  @JsonKey(name: "kanji_readings")
+  final List<KanjiReading> kanjiReadings;
+
 
   const Vocabulary(
       this.id,
@@ -42,7 +49,8 @@ class Vocabulary {
       this.romaji,
       this.relatedKanjis,
       this.version,
-      this.kanaSyllables);
+      this.kanaSyllables,
+      this.kanjiReadings);
 
   factory Vocabulary.fromJson(Map<String, dynamic> json) =>
       _$VocabularyFromJson(json);

--- a/lib/src/core/models/vocabulary.dart
+++ b/lib/src/core/models/vocabulary.dart
@@ -32,13 +32,13 @@ class Vocabulary {
 
   /// List of syllables forming the word in kana. Use to facilitate vocabulary sorting.
   @JsonKey(name: "kana_syllables")
-  final List<String> kanaSyllables; // TODO: To remove once migrated to "kanjiReadings"
+  final List<String>
+      kanaSyllables; // TODO: To remove once migrated to "kanjiReadings"
 
   /// List of kanji which are in the vocabulary with their respective reading
   @Default([])
   @JsonKey(name: "kanji_readings")
   final List<KanjiReading> kanjiReadings;
-
 
   const Vocabulary(
       this.id,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -545,10 +545,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -846,10 +846,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.11.0"
   stacked:
     dependency: "direct main"
     description:
@@ -870,10 +870,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -902,10 +902,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.0"
   timing:
     dependency: transitive
     description:
@@ -950,10 +950,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1003,5 +1003,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.1.0 <4.0.0"
   flutter: ">=3.13.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.19.0+1
+version: 0.19.1+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/test/src/core/repositories/kanji_repository_test.dart
+++ b/test/src/core/repositories/kanji_repository_test.dart
@@ -10,8 +10,8 @@ import 'kanji_repository_test.mocks.dart';
 
 void main() {
   group("KanjiRepository", () {
-    const kanjiSample =
-        Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
+    const kanjiSample = Kanji(
+        1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
     late KanjiRepository repository;
 
     final kanjiServiceMock = MockKanjiService();

--- a/test/src/core/repositories/kanji_repository_test.dart
+++ b/test/src/core/repositories/kanji_repository_test.dart
@@ -11,7 +11,7 @@ import 'kanji_repository_test.mocks.dart';
 void main() {
   group("KanjiRepository", () {
     const kanjiSample =
-        Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], "2023-12-1", [], []);
+        Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
     late KanjiRepository repository;
 
     final kanjiServiceMock = MockKanjiService();

--- a/test/src/core/repositories/vocabulary_repository_test.dart
+++ b/test/src/core/repositories/vocabulary_repository_test.dart
@@ -11,7 +11,7 @@ import 'vocabulary_repository_test.mocks.dart';
 void main() {
   group("VocabularyRepository", () {
     const Vocabulary vocabularySample =
-        Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", []);
+        Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
     late VocabularyRepository repository;
 
     final vocabularyServiceMock = MockVocabularyService();

--- a/test/src/core/widgets/furigana_text_test.dart
+++ b/test/src/core/widgets/furigana_text_test.dart
@@ -90,7 +90,7 @@ void main() {
         testWidgets("Kun reading should be used if available",
             (WidgetTester tester) async {
           const kanji =
-              Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], "2023-12-1", [], []);
+              Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
 
           final widget =
               await pump(tester, FuriganaText.kanji(kanji, showFurigana: true));
@@ -109,7 +109,7 @@ void main() {
         testWidgets("On reading should be used if there is no kun reading",
             (WidgetTester tester) async {
           const kanji = Kanji(1, "人", 5, 1, 5, ["person"], ["ジン", "ニン"], [],
-              "2023-12-1", [], []);
+              [], "2023-12-1", [], [], []);
 
           final widget =
               await pump(tester, FuriganaText.kanji(kanji, showFurigana: true));
@@ -127,7 +127,7 @@ void main() {
 
         testWidgets("Furigana should be override", (WidgetTester tester) async {
           const kanji = Kanji(
-              1, "本", 5, 1, 5, ["book"], [], ["ほん"], "2023-12-1", [], ["hon"]);
+              1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], ["hon"]);
           const furiganaOverride = "あ";
 
           final widget = await pump(
@@ -151,7 +151,7 @@ void main() {
         testWidgets("Should have main text and furigana",
             (WidgetTester tester) async {
           const vocabulary = Vocabulary(
-              1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", ["a"]);
+              1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", ["a"], []);
 
           final widget = await pump(
               tester, FuriganaText.vocabulary(vocabulary, showFurigana: true));
@@ -170,7 +170,7 @@ void main() {
 
         testWidgets("Should only have main text", (WidgetTester tester) async {
           const vocabulary = Vocabulary(
-              1, "", "あ", 1, ["inferior"], "a", [], "2023-12-1", ["a"]);
+              1, "", "あ", 1, ["inferior"], "a", [], "2023-12-1", ["a"], []);
 
           final widget = await pump(
               tester, FuriganaText.vocabulary(vocabulary, showFurigana: true));

--- a/test/src/core/widgets/furigana_text_test.dart
+++ b/test/src/core/widgets/furigana_text_test.dart
@@ -89,8 +89,8 @@ void main() {
       group("Kanji", () {
         testWidgets("Kun reading should be used if available",
             (WidgetTester tester) async {
-          const kanji =
-              Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
+          const kanji = Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], [],
+              "2023-12-1", [], [], []);
 
           final widget =
               await pump(tester, FuriganaText.kanji(kanji, showFurigana: true));
@@ -108,8 +108,8 @@ void main() {
 
         testWidgets("On reading should be used if there is no kun reading",
             (WidgetTester tester) async {
-          const kanji = Kanji(1, "人", 5, 1, 5, ["person"], ["ジン", "ニン"], [],
-              [], "2023-12-1", [], [], []);
+          const kanji = Kanji(1, "人", 5, 1, 5, ["person"], ["ジン", "ニン"], [], [],
+              "2023-12-1", [], [], []);
 
           final widget =
               await pump(tester, FuriganaText.kanji(kanji, showFurigana: true));
@@ -126,8 +126,8 @@ void main() {
         });
 
         testWidgets("Furigana should be override", (WidgetTester tester) async {
-          const kanji = Kanji(
-              1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], ["hon"]);
+          const kanji = Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], [],
+              "2023-12-1", [], [], ["hon"]);
           const furiganaOverride = "あ";
 
           final widget = await pump(

--- a/test/src/glossary/details/details_view_test.dart
+++ b/test/src/glossary/details/details_view_test.dart
@@ -58,7 +58,7 @@ void main() {
     testWidgets("Kanji", (WidgetTester tester) async {
       final theme = AppTheme.light();
       const kanjiSample =
-          Kanji(1, "本", 5, 5, 5, ["book"], [], ["ほん"], "2023-12-1", [], []);
+          Kanji(1, "本", 5, 5, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
       await pump(tester, const DetailsView(item: kanjiSample));
 
       // Check title section
@@ -84,7 +84,7 @@ void main() {
       testWidgets("With kanji", (WidgetTester tester) async {
         final theme = AppTheme.light();
         const vocabularySample =
-            Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", []);
+            Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
         await pump(tester, const DetailsView(item: vocabularySample));
 
         // Check title section
@@ -110,7 +110,7 @@ void main() {
       testWidgets("Without kanji", (WidgetTester tester) async {
         final theme = AppTheme.light();
         const vocabularySample =
-            Vocabulary(1, "", "あ", 1, ["inferior"], "a", [], "2023-12-1", []);
+            Vocabulary(1, "", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
         await pump(tester, const DetailsView(item: vocabularySample));
 
         // Check title section

--- a/test/src/glossary/details/details_view_test.dart
+++ b/test/src/glossary/details/details_view_test.dart
@@ -57,8 +57,8 @@ void main() {
 
     testWidgets("Kanji", (WidgetTester tester) async {
       final theme = AppTheme.light();
-      const kanjiSample =
-          Kanji(1, "本", 5, 5, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
+      const kanjiSample = Kanji(
+          1, "本", 5, 5, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
       await pump(tester, const DetailsView(item: kanjiSample));
 
       // Check title section
@@ -83,8 +83,8 @@ void main() {
     group("Vocabulary", () {
       testWidgets("With kanji", (WidgetTester tester) async {
         final theme = AppTheme.light();
-        const vocabularySample =
-            Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
+        const vocabularySample = Vocabulary(
+            1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
         await pump(tester, const DetailsView(item: vocabularySample));
 
         // Check title section
@@ -109,8 +109,8 @@ void main() {
 
       testWidgets("Without kanji", (WidgetTester tester) async {
         final theme = AppTheme.light();
-        const vocabularySample =
-            Vocabulary(1, "", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
+        const vocabularySample = Vocabulary(
+            1, "", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
         await pump(tester, const DetailsView(item: vocabularySample));
 
         // Check title section

--- a/test/src/glossary/details/widgets/details_test.dart
+++ b/test/src/glossary/details/widgets/details_test.dart
@@ -50,7 +50,7 @@ void main() {
 
     testWidgets("Kanji", (WidgetTester tester) async {
       const kanjiSample =
-          Kanji(1, "本", 5, 5, 5, ["book"], ["ほん"], ["ほん"], "2023-12-1", [], []);
+          Kanji(1, "本", 5, 5, 5, ["book"], ["ほん"], ["ほん"], [], "2023-12-1", [], [], []);
 
       final widget = await pump(tester, Details.kanji(kanji: kanjiSample));
 
@@ -83,7 +83,7 @@ void main() {
 
     testWidgets("Vocabulary", (WidgetTester tester) async {
       const vocabularySample =
-          Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", []);
+          Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
 
       final widget =
           await pump(tester, Details.vocabulary(vocabulary: vocabularySample));

--- a/test/src/glossary/details/widgets/details_test.dart
+++ b/test/src/glossary/details/widgets/details_test.dart
@@ -49,8 +49,8 @@ void main() {
     });
 
     testWidgets("Kanji", (WidgetTester tester) async {
-      const kanjiSample =
-          Kanji(1, "本", 5, 5, 5, ["book"], ["ほん"], ["ほん"], [], "2023-12-1", [], [], []);
+      const kanjiSample = Kanji(1, "本", 5, 5, 5, ["book"], ["ほん"], ["ほん"], [],
+          "2023-12-1", [], [], []);
 
       final widget = await pump(tester, Details.kanji(kanji: kanjiSample));
 
@@ -82,8 +82,8 @@ void main() {
     });
 
     testWidgets("Vocabulary", (WidgetTester tester) async {
-      const vocabularySample =
-          Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
+      const vocabularySample = Vocabulary(
+          1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
 
       final widget =
           await pump(tester, Details.vocabulary(vocabulary: vocabularySample));

--- a/test/src/glossary/widgets/glossary_list_tile_test.dart
+++ b/test/src/glossary/widgets/glossary_list_tile_test.dart
@@ -9,8 +9,8 @@ import '../../../helpers.dart';
 
 void main() {
   group("GlossaryListTile", () {
-    const kanji =
-        Kanji(1, "本", 5, 5, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
+    const kanji = Kanji(
+        1, "本", 5, 5, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
 
     Future<Finder> pump(WidgetTester tester, Widget widget) async {
       await tester.pumpLocalizedWidget(widget);
@@ -52,8 +52,8 @@ void main() {
       });
 
       testWidgets("Vocabulary", (WidgetTester tester) async {
-        const vocabulary =
-            Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
+        const vocabulary = Vocabulary(
+            1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
         final AppLocalizations l10n = await setupLocalizations();
 
         final widget =

--- a/test/src/glossary/widgets/glossary_list_tile_test.dart
+++ b/test/src/glossary/widgets/glossary_list_tile_test.dart
@@ -10,7 +10,7 @@ import '../../../helpers.dart';
 void main() {
   group("GlossaryListTile", () {
     const kanji =
-        Kanji(1, "本", 5, 5, 5, ["book"], [], ["ほん"], "2023-12-1", [], []);
+        Kanji(1, "本", 5, 5, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
 
     Future<Finder> pump(WidgetTester tester, Widget widget) async {
       await tester.pumpLocalizedWidget(widget);
@@ -53,7 +53,7 @@ void main() {
 
       testWidgets("Vocabulary", (WidgetTester tester) async {
         const vocabulary =
-            Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", []);
+            Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], []);
         final AppLocalizations l10n = await setupLocalizations();
 
         final widget =

--- a/test/src/glossary/widgets/kanji_list_test.dart
+++ b/test/src/glossary/widgets/kanji_list_test.dart
@@ -8,7 +8,7 @@ import '../../../helpers.dart';
 void main() {
   group("KanjiList", () {
     const kanji =
-        Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], "2023-12-1", [], []);
+        Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
 
     testWidgets("Empty list", (WidgetTester tester) async {
       await tester.pumpLocalizedWidget(const KanjiList(

--- a/test/src/glossary/widgets/kanji_list_test.dart
+++ b/test/src/glossary/widgets/kanji_list_test.dart
@@ -7,8 +7,8 @@ import '../../../helpers.dart';
 
 void main() {
   group("KanjiList", () {
-    const kanji =
-        Kanji(1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
+    const kanji = Kanji(
+        1, "本", 5, 1, 5, ["book"], [], ["ほん"], [], "2023-12-1", [], [], []);
 
     testWidgets("Empty list", (WidgetTester tester) async {
       await tester.pumpLocalizedWidget(const KanjiList(

--- a/test/src/glossary/widgets/vocabulary_list_test.dart
+++ b/test/src/glossary/widgets/vocabulary_list_test.dart
@@ -8,8 +8,8 @@ import '../../../helpers.dart';
 
 void main() {
   group("VocabularyList", () {
-    const vocabulary =
-        Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", ["a"], []);
+    const vocabulary = Vocabulary(
+        1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", ["a"], []);
 
     testWidgets("Empty list", (WidgetTester tester) async {
       await tester.pumpLocalizedWidget(const VocabularyList(
@@ -44,7 +44,8 @@ void main() {
     testWidgets("Contains 2 items", (WidgetTester tester) async {
       List<Vocabulary> vocabularyList = [
         vocabulary,
-        const Vocabulary(2, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], [])
+        const Vocabulary(
+            2, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], [])
       ];
       await tester.pumpLocalizedWidget(VocabularyList(
         items: vocabularyList,

--- a/test/src/glossary/widgets/vocabulary_list_test.dart
+++ b/test/src/glossary/widgets/vocabulary_list_test.dart
@@ -9,7 +9,7 @@ import '../../../helpers.dart';
 void main() {
   group("VocabularyList", () {
     const vocabulary =
-        Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", ["a"]);
+        Vocabulary(1, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", ["a"], []);
 
     testWidgets("Empty list", (WidgetTester tester) async {
       await tester.pumpLocalizedWidget(const VocabularyList(
@@ -44,7 +44,7 @@ void main() {
     testWidgets("Contains 2 items", (WidgetTester tester) async {
       List<Vocabulary> vocabularyList = [
         vocabulary,
-        const Vocabulary(2, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [])
+        const Vocabulary(2, "亜", "あ", 1, ["inferior"], "a", [], "2023-12-1", [], [])
       ];
       await tester.pumpLocalizedWidget(VocabularyList(
         items: vocabularyList,


### PR DESCRIPTION
…with pagination and new fields

## 📖 Description
Update the application to be able to use the latest version of the API with the new fields and pagination.

### ⁉️ Related Issues
None

### 🧪 How to test the change?
- Start the app
- Go to the Glossary
- Go to the "Kanji" tab
- Go to the "Vocabulary" tab

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.