### PR TITLE
refactor: Call /sync to know which data sync needs to be done

### DIFF
--- a/lib/src/core/models/sync.dart
+++ b/lib/src/core/models/sync.dart
@@ -1,0 +1,39 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:isar/isar.dart';
+
+part 'sync.g.dart';
+
+@embedded
+@JsonSerializable()
+class Sync {
+  final bool achievements;
+  final bool cleanup;
+  @JsonKey(name: "groups")
+  final bool groupsFlag;
+  final bool kana;
+  final bool kanji;
+  final LearningSync learning;
+  final bool vocabulary;
+
+  const Sync(
+      {required this.achievements,
+      required this.cleanup,
+      required this.groupsFlag,
+      required this.kana,
+      required this.kanji,
+      required this.learning,
+      required this.vocabulary});
+
+  factory Sync.fromJson(Map<String, dynamic> json) => _$SyncFromJson(json);
+}
+
+@embedded
+@JsonSerializable()
+class LearningSync {
+  final bool stages;
+
+  const LearningSync({required this.stages});
+
+  factory LearningSync.fromJson(Map<String, dynamic> json) =>
+      _$LearningSyncFromJson(json);
+}

--- a/lib/src/core/services/sync_service.dart
+++ b/lib/src/core/services/sync_service.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:isar/isar.dart';
+import 'package:kana_to_kanji/src/core/models/group.dart';
+import 'package:kana_to_kanji/src/core/models/kana.dart';
+import 'package:kana_to_kanji/src/core/models/kanji.dart';
+import 'package:kana_to_kanji/src/core/models/sync.dart';
+import 'package:kana_to_kanji/src/core/models/vocabulary.dart';
+import 'package:kana_to_kanji/src/core/services/api_service.dart';
+import 'package:kana_to_kanji/src/locator.dart';
+
+class SyncService {
+  final ApiService _apiService = locator<ApiService>();
+  final Isar _isar = locator<Isar>();
+
+  Future<Sync> getSyncData() {
+    var lastLoadedVersionGroups = _isar.groups.where().versionProperty().max();
+    var lastLoadedVersionKanas = _isar.kanas.where().versionProperty().max();
+    var lastLoadedVersionKanjis = _isar.kanjis.where().versionProperty().max();
+    var lastLoadedVersionVocabulary =
+        _isar.vocabularys.where().versionProperty().max();
+
+    var versionQueryParam = "";
+    if (lastLoadedVersionGroups != null &&
+        lastLoadedVersionGroups.compareTo(versionQueryParam) > 0) {
+      versionQueryParam = "?version[current]=$lastLoadedVersionGroups";
+    }
+    if (lastLoadedVersionKanas != null &&
+        lastLoadedVersionKanas.compareTo(versionQueryParam) > 0) {
+      versionQueryParam = "?version[current]=$lastLoadedVersionKanas";
+    }
+    if (lastLoadedVersionKanjis != null &&
+        lastLoadedVersionKanjis.compareTo(versionQueryParam) > 0) {
+      versionQueryParam = "?version[current]=$lastLoadedVersionKanjis";
+    }
+    if (lastLoadedVersionVocabulary != null &&
+        lastLoadedVersionVocabulary.compareTo(versionQueryParam) > 0) {
+      versionQueryParam = "?version[current]=$lastLoadedVersionVocabulary";
+    }
+
+    return _apiService
+        .get('/v1/sync$versionQueryParam')
+        .then((response) => _extractData(response));
+  }
+
+  /// Extract the Sync data from the API Response.
+  Sync _extractData(http.Response response) {
+    if (response.statusCode == 200) {
+      var jsonData = jsonDecode(response.body);
+      Sync data = Sync.fromJson(jsonData);
+      return data;
+    } else if (response.statusCode == 404) {
+      // If the server did return a 404 response,
+      // returns an sync object with all flags to true.
+      return const Sync(
+          achievements: true,
+          cleanup: true,
+          groupsFlag: true,
+          kana: true,
+          kanji: true,
+          learning: LearningSync(stages: true),
+          vocabulary: true);
+    } else {
+      // If the server did return something else,
+      // returns an sync object with all flags to false.
+      return const Sync(
+          achievements: false,
+          cleanup: false,
+          groupsFlag: false,
+          kana: false,
+          kanji: false,
+          learning: LearningSync(stages: false),
+          vocabulary: false);
+    }
+  }
+}

--- a/lib/src/locator.dart
+++ b/lib/src/locator.dart
@@ -18,6 +18,7 @@ import 'package:kana_to_kanji/src/core/services/api_service.dart';
 import 'package:kana_to_kanji/src/core/services/dialog_service.dart';
 import 'package:kana_to_kanji/src/core/services/info_service.dart';
 import 'package:kana_to_kanji/src/core/services/preferences_service.dart';
+import 'package:kana_to_kanji/src/core/services/sync_service.dart';
 import 'package:logger/logger.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -29,7 +30,9 @@ void setupLocator() {
   // Services
   locator.registerSingleton<DialogService>(DialogService());
   locator.registerLazySingleton<PreferencesService>(() => PreferencesService());
-  locator.registerLazySingleton<ApiService>(() => ApiService());
+  locator.registerSingletonAsync<ApiService>(() async {
+    return ApiService();
+  });
   locator.registerSingletonAsync<InfoService>(() async {
     final instance = InfoService();
     await instance.initialize();
@@ -68,24 +71,52 @@ void setupLocator() {
   locator.registerSingleton<SettingsRepository>(SettingsRepository());
 
   // Data Loaders
-  locator.registerSingletonAsync<GroupDataLoader>(() async {
-    final instance = GroupDataLoader();
-    instance.loadCollection();
+  locator.registerSingletonAsync<SyncService>(() async {
+    final instance = SyncService();
+
+    // Get the sync data to know which calls need to be done.
+    var sync = await instance.getSyncData();
+
+    // - Group
+    locator.registerSingletonAsync<GroupDataLoader>(() async {
+      final instance = GroupDataLoader();
+      if (sync.groupsFlag) {
+        // Load the collection only if required
+        instance.loadCollection();
+      }
+      return instance;
+    }, dependsOn: [Isar]);
+
+    // - Kana
+    locator.registerSingletonAsync<KanaDataLoader>(() async {
+      final instance = KanaDataLoader();
+      if (sync.kana) {
+        // Load the collection only if required
+        instance.loadCollection();
+      }
+      return instance;
+    }, dependsOn: [Isar]);
+
+    // - Kanji
+    locator.registerSingletonAsync<KanjiDataLoader>(() async {
+      final instance = KanjiDataLoader();
+      if (sync.kanji) {
+        // Load the collection only if required
+        instance.loadCollection();
+      }
+      return instance;
+    }, dependsOn: [Isar]);
+
+    // - Vocabulary
+    locator.registerSingletonAsync<VocabularyDataLoader>(() async {
+      final instance = VocabularyDataLoader();
+      if (sync.vocabulary) {
+        // Load the collection only if required
+        instance.loadCollection();
+      }
+      return instance;
+    }, dependsOn: [Isar]);
+
     return instance;
-  }, dependsOn: [Isar]);
-  locator.registerSingletonAsync<KanaDataLoader>(() async {
-    final instance = KanaDataLoader();
-    instance.loadCollection();
-    return instance;
-  }, dependsOn: [Isar]);
-  locator.registerSingletonAsync<KanjiDataLoader>(() async {
-    final instance = KanjiDataLoader();
-    instance.loadCollection();
-    return instance;
-  }, dependsOn: [Isar]);
-  locator.registerSingletonAsync<VocabularyDataLoader>(() async {
-    final instance = VocabularyDataLoader();
-    instance.loadCollection();
-    return instance;
-  }, dependsOn: [Isar]);
+  }, dependsOn: [ApiService, Isar]);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.22.0+1
+version: 0.23.0+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'


### PR DESCRIPTION
## 📖 Description
Update the locator initialization to call first `GET /sync` to know which static data endpoints needs to be called.

### ⁉️ Related Issues
closes #219 

### 🧪 How to test the change?
- Open the API logs
- Start the application without local cache
- Check the API logs. The next calls must be done
  - GET /sync
  - GET on each kind of static data *(kana, kanji...)*
- Close the application
- Open the application
- Check the API logs. Only the `GET /sync` call must have been done.
- Close the application
- Update the database to have a new version which add or update a kana
- Open the application
- Check the API logs. Only 2 calls must have been done :
  - `GET /sync`
  - `GET /kana`

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.