### PR TITLE
fix: Paginate Kanji and Vocabulary list to reduce display cost

### DIFF
--- a/lib/src/glossary/widgets/vocabulary_list.dart
+++ b/lib/src/glossary/widgets/vocabulary_list.dart
@@ -7,7 +7,7 @@ class VocabularyList extends StatefulWidget {
   final List<Vocabulary> items;
 
   /// Function to execute when a [GlossaryListTile] is pressed
-  final Function(Vocabulary kanji)? onPressed;
+  final Function(Vocabulary vocabulary)? onPressed;
 
   const VocabularyList({required this.items, super.key, this.onPressed});
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.25.5+1
+version: 0.26.0+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'


### PR DESCRIPTION
## 📖 Description
Add pagination for Kanji and vocabulary in the glossary.

### ⁉️ Related Issues
closes #118 

### 🧪 How to test the change?
- Open the application
- Go to the Glossary tab
- Go to the Kanji or Vocabulary tab
- Scroll down

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.