### PR TITLE
fix: Only execute search, filter and sort on the current tab

### DIFF
--- a/lib/src/core/constants/glossary_tab.dart
+++ b/lib/src/core/constants/glossary_tab.dart
@@ -1,0 +1,25 @@
+enum GlossaryTab {
+  hiragana(0),
+  katakana(1),
+  kanji(2),
+  vocabulary(3);
+
+  final int value;
+
+  const GlossaryTab(this.value);
+
+  static GlossaryTab getValue(int index) {
+    switch (index) {
+      case 0:
+        return GlossaryTab.hiragana;
+      case 1:
+        return GlossaryTab.katakana;
+      case 2:
+        return GlossaryTab.kanji;
+      case 3:
+        return GlossaryTab.vocabulary;
+      default:
+        return GlossaryTab.hiragana;
+    }
+  }
+}

--- a/lib/src/glossary/glossary_view.dart
+++ b/lib/src/glossary/glossary_view.dart
@@ -41,7 +41,8 @@ class _GlossaryViewState extends State<GlossaryView>
     const textIconStyle = TextStyle(fontSize: 26);
 
     return ViewModelBuilder<GlossaryViewModel>.reactive(
-        viewModelBuilder: () => GlossaryViewModel(GoRouter.of(context)),
+        viewModelBuilder: () =>
+            GlossaryViewModel(GoRouter.of(context), _tabController),
         builder: (context, viewModel, child) => AppScaffold(
               showBottomBar: true,
               appBar: AppBar(

--- a/lib/src/glossary/glossary_view_model.dart
+++ b/lib/src/glossary/glossary_view_model.dart
@@ -1,4 +1,6 @@
+import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
+import "package:kana_to_kanji/src/core/constants/glossary_tab.dart";
 import "package:kana_to_kanji/src/core/constants/jlpt_levels.dart";
 import "package:kana_to_kanji/src/core/constants/knowledge_level.dart";
 import "package:kana_to_kanji/src/core/constants/sort_order.dart";
@@ -15,6 +17,8 @@ import "package:stacked/stacked.dart";
 
 class GlossaryViewModel extends FutureViewModel {
   final GoRouter router;
+  final TabController _tabController;
+  int _currentTab = 0;
 
   final DialogService _dialogService = locator<DialogService>();
   final KanaRepository _kanaRepository = locator<KanaRepository>();
@@ -43,38 +47,63 @@ class GlossaryViewModel extends FutureViewModel {
   List<KnowledgeLevel> get selectedKnowledgeLevel => _selectedKnowledgeLevel;
   SortOrder selectedOrder = SortOrder.japanese;
 
-  GlossaryViewModel(this.router);
+  GlossaryViewModel(this.router, this._tabController);
 
   @override
   Future futureToRun() async {
-    _hiraganaList.addAll(_kanaRepository
-        .getHiragana()
-        .map((kana) => (kana: kana, disabled: false)));
-    _katakanaList.addAll(_kanaRepository
-        .getKatakana()
-        .map((kana) => (kana: kana, disabled: false)));
-    _kanjiList.addAll(_kanjiRepository.getAll());
-    _vocabularyList.addAll(_vocabularyRepository.getAll());
+    _tabController.addListener(_handleTabSelection);
+    _setToDisplay();
   }
 
+  void _handleTabSelection() {
+    if (_currentTab != _tabController.index) {
+      _currentTab = _tabController.index;
+      _setToDisplay();
+    }
+  }
+
+  /// Update the current searched text and update the lists to display.
   void searchGlossary(String searchText) {
     _currentSearch = searchText;
     _setToDisplay();
     notifyListeners();
   }
 
+  /// Triggers list update following the change of filters.
   void filterGlossary() {
     _setToDisplay();
     notifyListeners();
   }
 
+  /// Update the selected order and update the lists to display.
   void sortGlossary(SortOrder newSelectedOrder) {
     selectedOrder = newSelectedOrder;
     _setToDisplay();
     notifyListeners();
   }
 
+  /// Update the list of values to display of the current tab.
   void _setToDisplay() {
+    switch (GlossaryTab.getValue(_tabController.index)) {
+      case GlossaryTab.hiragana:
+        _updateHiraganaList();
+      case GlossaryTab.katakana:
+        _updateKatakanaList();
+      case GlossaryTab.kanji:
+        _updateKanjiList();
+      case GlossaryTab.vocabulary:
+        _updateVocabularyList();
+    }
+  }
+
+  /// Update the hiragana list to display based on the current search
+  /// and selected knowledge levels.
+  void _updateHiraganaList() {
+    if (_hiraganaList.isEmpty) {
+      _hiraganaList.addAll(_kanaRepository
+          .getHiragana()
+          .map((kana) => (kana: kana, disabled: false)));
+    }
     final hiraganaIdsFiltered = _kanaRepository
         .searchHiragana(_currentSearch, _selectedKnowledgeLevel)
         .map((e) => e.uid);
@@ -84,7 +113,16 @@ class GlossaryViewModel extends FutureViewModel {
         disabled: !hiraganaIdsFiltered.contains(pair.kana.uid)
       );
     }
+  }
 
+  /// Update the katakana list to display based on the current search
+  /// and selected knowledge levels.
+  void _updateKatakanaList() {
+    if (_katakanaList.isEmpty) {
+      _katakanaList.addAll(_kanaRepository
+          .getKatakana()
+          .map((kana) => (kana: kana, disabled: false)));
+    }
     final katakanaIdsFiltered = _kanaRepository
         .searchKatakana(_currentSearch, _selectedKnowledgeLevel)
         .map((e) => e.uid);
@@ -94,17 +132,33 @@ class GlossaryViewModel extends FutureViewModel {
         disabled: !katakanaIdsFiltered.contains(pair.kana.uid)
       );
     }
-
-    _kanjiList
-      ..clear()
-      ..addAll(_kanjiRepository.searchKanji(_currentSearch,
-          _selectedKnowledgeLevel, _selectedJlptLevel, selectedOrder));
-    _vocabularyList
-      ..clear()
-      ..addAll(_vocabularyRepository.searchVocabulary(_currentSearch,
-          _selectedKnowledgeLevel, _selectedJlptLevel, selectedOrder));
   }
 
+  /// Update the kanji list to display based on all the filter/search configurations.
+  void _updateKanjiList() {
+    _kanjiList
+      ..clear()
+      ..addAll(_kanjiRepository.searchKanji(
+        _currentSearch,
+        _selectedKnowledgeLevel,
+        _selectedJlptLevel,
+        selectedOrder,
+      ));
+  }
+
+  /// Update the vocabulary list to display based on all the filter/search configurations.
+  void _updateVocabularyList() {
+    _vocabularyList
+      ..clear()
+      ..addAll(_vocabularyRepository.searchVocabulary(
+        _currentSearch,
+        _selectedKnowledgeLevel,
+        _selectedJlptLevel,
+        selectedOrder,
+      ));
+  }
+
+  /// Displays a modal with the informations of the selected item.
   Future<void> onTilePressed(dynamic item) async {
     await _dialogService.showModalBottomSheet(
         useSafeArea: true,

--- a/lib/src/glossary/widgets/vocabulary_list.dart
+++ b/lib/src/glossary/widgets/vocabulary_list.dart
@@ -7,7 +7,7 @@ class VocabularyList extends StatefulWidget {
   final List<Vocabulary> items;
 
   /// Function to execute when a [GlossaryListTile] is pressed
-  final Function(Vocabulary vocabulary)? onPressed;
+  final Function(Vocabulary kanji)? onPressed;
 
   const VocabularyList({required this.items, super.key, this.onPressed});
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1067,5 +1067,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.27.0+1
+version: 0.28.0+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/test/src/glossary/glossary_view_model_test.dart
+++ b/test/src/glossary/glossary_view_model_test.dart
@@ -1,0 +1,328 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
+import "package:kana_to_kanji/src/core/constants/sort_order.dart";
+import "package:kana_to_kanji/src/core/repositories/kana_repository.dart";
+import "package:kana_to_kanji/src/core/repositories/kanji_repository.dart";
+import "package:kana_to_kanji/src/core/repositories/vocabulary_repository.dart";
+import "package:kana_to_kanji/src/core/services/dialog_service.dart";
+import "package:kana_to_kanji/src/glossary/glossary_view_model.dart";
+import "package:kana_to_kanji/src/locator.dart";
+import "package:mockito/annotations.dart";
+import "package:mockito/mockito.dart";
+
+import "../../dummies/kana.dart";
+import "../../dummies/kanji.dart";
+import "../../dummies/vocabulary.dart";
+@GenerateNiceMocks([
+  MockSpec<GoRouter>(),
+  MockSpec<TabController>(),
+  MockSpec<DialogService>(),
+  MockSpec<KanaRepository>(),
+  MockSpec<KanjiRepository>(),
+  MockSpec<VocabularyRepository>()
+])
+import "glossary_view_model_test.mocks.dart";
+
+final TabController tabControllerMock = MockTabController();
+final GoRouter goRouterMock = MockGoRouter();
+final KanaRepository kanaRepositoryMock = MockKanaRepository();
+final KanjiRepository kanjiRepositoryMock = MockKanjiRepository();
+final VocabularyRepository vocabularyRepositoryMock =
+    MockVocabularyRepository();
+final DialogService dialogServiceMock = MockDialogService();
+
+void main() {
+  group("GlossaryViewModel", () {
+    when(kanaRepositoryMock.getHiragana())
+        .thenAnswer((_) => [dummyHiragana, dummyHiragana]);
+    when(kanaRepositoryMock.searchHiragana("", []))
+        .thenAnswer((_) => [dummyHiragana, dummyHiragana]);
+    when(kanaRepositoryMock.searchHiragana("toto", []))
+        .thenAnswer((_) => [dummyHiragana, dummyHiragana]);
+
+    when(kanaRepositoryMock.getKatakana())
+        .thenAnswer((_) => [dummyKatakana, dummyKatakana, dummyKatakana]);
+    when(kanaRepositoryMock.searchKatakana("", []))
+        .thenAnswer((_) => [dummyKatakana, dummyKatakana, dummyKatakana]);
+    when(kanaRepositoryMock.searchKatakana("toto", []))
+        .thenAnswer((_) => [dummyKatakana, dummyKatakana, dummyKatakana]);
+
+    when(vocabularyRepositoryMock.searchVocabulary(
+            "", [], [], SortOrder.japanese))
+        .thenAnswer((_) => [dummyVocabulary]);
+    when(vocabularyRepositoryMock.searchVocabulary(
+            "toto", [], [], SortOrder.japanese))
+        .thenAnswer((_) => [dummyVocabulary, dummyVocabulary, dummyVocabulary]);
+
+    when(kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese))
+        .thenAnswer((_) => [dummyKanji, dummyKanji, dummyKanji, dummyKanji]);
+    when(kanjiRepositoryMock.searchKanji("toto", [], [], SortOrder.japanese))
+        .thenAnswer((_) => [dummyKanji]);
+
+    setUpAll(() async {
+      locator
+        ..registerSingleton<DialogService>(dialogServiceMock)
+        ..registerSingleton<KanaRepository>(kanaRepositoryMock)
+        ..registerSingleton<KanjiRepository>(kanjiRepositoryMock)
+        ..registerSingleton<VocabularyRepository>(vocabularyRepositoryMock);
+    });
+
+    testWidgets("New GlossaryViewModel open nothing",
+        (WidgetTester tester) async {
+      when(tabControllerMock.index).thenAnswer((_) => 0);
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock);
+
+      checkLists(gvm, 0, 0, 0, 0);
+      verifyNever(kanaRepositoryMock.getHiragana());
+      verifyNever(kanaRepositoryMock.searchHiragana("", []));
+      verifyNever(kanaRepositoryMock.searchHiragana("toto", []));
+      verifyNever(kanaRepositoryMock.getKatakana());
+      verifyNever(kanaRepositoryMock.searchKatakana("", []));
+      verifyNever(kanaRepositoryMock.searchKatakana("toto", []));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("toto", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "toto", [], [], SortOrder.japanese));
+    });
+
+    testWidgets("New GlossaryViewModel open on the Hiragana tab",
+        (WidgetTester tester) async {
+      when(tabControllerMock.index).thenAnswer((_) => 0);
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock);
+      await gvm.futureToRun();
+
+      checkLists(gvm, 2, 0, 0, 0);
+      verify(kanaRepositoryMock.getHiragana()).called(1);
+      verify(kanaRepositoryMock.searchHiragana("", [])).called(1);
+      verifyNever(kanaRepositoryMock.searchHiragana("toto", []));
+      verifyNever(kanaRepositoryMock.getKatakana());
+      verifyNever(kanaRepositoryMock.searchKatakana("", []));
+      verifyNever(kanaRepositoryMock.searchKatakana("toto", []));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("toto", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "toto", [], [], SortOrder.japanese));
+    });
+
+    testWidgets("New GlossaryViewModel open on the Katakana tab",
+        (WidgetTester tester) async {
+      when(tabControllerMock.index).thenAnswer((_) => 1);
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock);
+      await gvm.futureToRun();
+
+      checkLists(gvm, 0, 3, 0, 0);
+      verifyNever(kanaRepositoryMock.getHiragana());
+      verifyNever(kanaRepositoryMock.searchHiragana("", []));
+      verifyNever(kanaRepositoryMock.searchHiragana("toto", []));
+      verify(kanaRepositoryMock.getKatakana()).called(1);
+      verify(kanaRepositoryMock.searchKatakana("", [])).called(1);
+      verifyNever(kanaRepositoryMock.searchKatakana("toto", []));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("toto", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "toto", [], [], SortOrder.japanese));
+    });
+
+    testWidgets("New GlossaryViewModel open on the Kanji tab",
+        (WidgetTester tester) async {
+      when(tabControllerMock.index).thenAnswer((_) => 2);
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock);
+      await gvm.futureToRun();
+
+      checkLists(gvm, 0, 0, 4, 0);
+      verifyNever(kanaRepositoryMock.getHiragana());
+      verifyNever(kanaRepositoryMock.searchHiragana("", []));
+      verifyNever(kanaRepositoryMock.searchHiragana("toto", []));
+      verifyNever(kanaRepositoryMock.getKatakana());
+      verifyNever(kanaRepositoryMock.searchKatakana("", []));
+      verifyNever(kanaRepositoryMock.searchKatakana("toto", []));
+      verify(kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese))
+          .called(1);
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("toto", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "toto", [], [], SortOrder.japanese));
+    });
+
+    testWidgets("New GlossaryViewModel open on the Vocabulary tab",
+        (WidgetTester tester) async {
+      when(tabControllerMock.index).thenAnswer((_) => 3);
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock);
+      await gvm.futureToRun();
+
+      checkLists(gvm, 0, 0, 0, 1);
+      verifyNever(kanaRepositoryMock.getHiragana());
+      verifyNever(kanaRepositoryMock.searchHiragana("", []));
+      verifyNever(kanaRepositoryMock.searchHiragana("toto", []));
+      verifyNever(kanaRepositoryMock.getKatakana());
+      verifyNever(kanaRepositoryMock.searchKatakana("", []));
+      verifyNever(kanaRepositoryMock.searchKatakana("toto", []));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("toto", [], [], SortOrder.japanese));
+      verify(vocabularyRepositoryMock.searchVocabulary(
+              "", [], [], SortOrder.japanese))
+          .called(1);
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "toto", [], [], SortOrder.japanese));
+    });
+
+    testWidgets("Search on the Hiragana tab", (WidgetTester tester) async {
+      when(tabControllerMock.index).thenAnswer((_) => 0);
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock)
+            ..searchGlossary("toto");
+
+      checkLists(gvm, 2, 0, 0, 0);
+      verify(kanaRepositoryMock.getHiragana()).called(1);
+      verifyNever(kanaRepositoryMock.searchHiragana("", []));
+      verify(kanaRepositoryMock.searchHiragana("toto", [])).called(1);
+      verifyNever(kanaRepositoryMock.getKatakana());
+      verifyNever(kanaRepositoryMock.searchKatakana("", []));
+      verifyNever(kanaRepositoryMock.searchKatakana("toto", []));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("toto", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "toto", [], [], SortOrder.japanese));
+    });
+
+    testWidgets("Search on the Katakana tab", (WidgetTester tester) async {
+      when(tabControllerMock.index).thenAnswer((_) => 1);
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock)
+            ..searchGlossary("toto");
+
+      checkLists(gvm, 0, 3, 0, 0);
+      verifyNever(kanaRepositoryMock.getHiragana());
+      verifyNever(kanaRepositoryMock.searchHiragana("", []));
+      verifyNever(kanaRepositoryMock.searchHiragana("toto", []));
+      verify(kanaRepositoryMock.getKatakana()).called(1);
+      verifyNever(kanaRepositoryMock.searchKatakana("", []));
+      verify(kanaRepositoryMock.searchKatakana("toto", [])).called(1);
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("toto", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "toto", [], [], SortOrder.japanese));
+    });
+
+    testWidgets("Search on the Vocabulary tab", (WidgetTester tester) async {
+      when(tabControllerMock.index).thenAnswer((_) => 3);
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock)
+            ..searchGlossary("toto");
+
+      checkLists(gvm, 0, 0, 0, 3);
+      verifyNever(kanaRepositoryMock.getHiragana());
+      verifyNever(kanaRepositoryMock.searchHiragana("", []));
+      verifyNever(kanaRepositoryMock.searchHiragana("toto", []));
+      verifyNever(kanaRepositoryMock.getKatakana());
+      verifyNever(kanaRepositoryMock.searchKatakana("", []));
+      verifyNever(kanaRepositoryMock.searchKatakana("toto", []));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("toto", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "", [], [], SortOrder.japanese));
+      verify(vocabularyRepositoryMock.searchVocabulary(
+              "toto", [], [], SortOrder.japanese))
+          .called(1);
+    });
+
+    testWidgets("Search on the Kanji tab", (WidgetTester tester) async {
+      when(tabControllerMock.index).thenAnswer((_) => 2);
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock)
+            ..searchGlossary("toto");
+
+      checkLists(gvm, 0, 0, 1, 0);
+      verifyNever(kanaRepositoryMock.getHiragana());
+      verifyNever(kanaRepositoryMock.searchHiragana("", []));
+      verifyNever(kanaRepositoryMock.searchHiragana("toto", []));
+      verifyNever(kanaRepositoryMock.getKatakana());
+      verifyNever(kanaRepositoryMock.searchKatakana("", []));
+      verifyNever(kanaRepositoryMock.searchKatakana("toto", []));
+      verifyNever(
+          kanjiRepositoryMock.searchKanji("", [], [], SortOrder.japanese));
+      verify(kanjiRepositoryMock.searchKanji(
+              "toto", [], [], SortOrder.japanese))
+          .called(1);
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "", [], [], SortOrder.japanese));
+      verifyNever(vocabularyRepositoryMock.searchVocabulary(
+          "toto", [], [], SortOrder.japanese));
+    });
+
+    testWidgets("Switch between tabs", (WidgetTester tester) async {
+      final indexes = [0, 3, 1, 2];
+      when(tabControllerMock.index).thenAnswer((_) => indexes.removeAt(0));
+
+      final GlossaryViewModel gvm =
+          GlossaryViewModel(goRouterMock, tabControllerMock);
+
+      checkLists(gvm, 0, 0, 0, 0);
+
+      await gvm.futureToRun();
+
+      checkLists(gvm, 2, 0, 0, 0);
+
+      await gvm.futureToRun();
+
+      checkLists(gvm, 2, 0, 0, 1);
+
+      await gvm.futureToRun();
+
+      checkLists(gvm, 2, 3, 0, 1);
+
+      await gvm.futureToRun();
+
+      checkLists(gvm, 2, 3, 4, 1);
+    });
+  });
+}
+
+void checkLists(GlossaryViewModel gvm, int hiraganaListLength,
+    int katakanaListLength, int kanjiListLength, int vocabularyListLength) {
+  expect(gvm.hiraganaList.length, hiraganaListLength);
+  expect(gvm.katakanaList.length, katakanaListLength);
+  expect(gvm.kanjiList.length, kanjiListLength);
+  expect(gvm.vocabularyList.length, vocabularyListLength);
+}


### PR DESCRIPTION
## Prerequisites
### Related PR
- https://github.com/RoadTripMoustache/kana_to_kanji/pull/251
- https://github.com/RoadTripMoustache/kana_to_kanji/pull/259

## 📖 Description
Update code to execute search, filter and sort, only on the current tab. If a search / filter / sort is made while being on a tab *(like Kanji)*, the update will be made on the others when the user will select a other tab. 

### ⁉️ Related Issues
closes : #116 

### 🖼️ Screenshots:
<!--- Use the spoiler system for your screenshots/videos -->

<details>
    <summary>Test that it doesn't break everything</summary> 

[issue_116.webm](https://github.com/RoadTripMoustache/kana_to_kanji/assets/36586573/93956e0c-3313-4127-8682-6afb9cced142)

</details>

### 🧪 How to test the change?
- Open the application
- Go to the `Glossary` 
- Change to `Kanji` tab
- Update filters
- Change to `Vocabulary` tab
- Change to `Hiragana` tab
- Update search
- Change to `Katakana` tab
- Change to `Kanji` tab

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.