### PR TITLE
fix: Improve sorting of japanese words

### DIFF
--- a/lib/src/core/models/kanji.dart
+++ b/lib/src/core/models/kanji.dart
@@ -61,7 +61,7 @@ class Kanji {
   /// List of syllables of the first kanji Kun reading
   /// to facilitate the kanji sorting
   @JsonKey(name: "jp_sort_syllables")
-  final List<String> jpSortSyllables;
+  final List<int> jpSortSyllables;
 
   /// Usage examples of the kanji
   @Default([])

--- a/lib/src/core/models/vocabulary.dart
+++ b/lib/src/core/models/vocabulary.dart
@@ -40,7 +40,7 @@ class Vocabulary {
   /// List of syllables forming the word in kana.
   /// Use to facilitate vocabulary sorting.
   @JsonKey(name: "kana_syllables")
-  final List<String>
+  final List<int>
       kanaSyllables; // TODO: To remove once migrated to "kanjiReadings"
 
   /// List of kanji which are in the vocabulary with their respective reading

--- a/lib/src/core/utils/kana_utils.dart
+++ b/lib/src/core/utils/kana_utils.dart
@@ -221,7 +221,7 @@ const List<String> jpOrder = [
   "ン"
 ];
 
-List<String> splitBySyllable(String kanaWord) {
+List<int> splitBySyllable(String kanaWord) {
   final List<String> syllables = kanaWord.split("");
 
   for (var i = 0; i < syllables.length; i++) {
@@ -233,15 +233,13 @@ List<String> splitBySyllable(String kanaWord) {
     }
   }
 
-  return syllables;
+  return syllables.map((e) => jpOrder.indexOf(e)).toList();
 }
 
-int sortBySyllables(List<String> syllablesA, List<String> syllablesB) {
+int sortBySyllables(List<int> syllablesA, List<int> syllablesB) {
   int index = 0;
   while (index < syllablesA.length && index < syllablesB.length) {
-    final int comparison = jpOrder
-        .indexOf(syllablesA[index])
-        .compareTo(jpOrder.indexOf(syllablesB[index]));
+    final int comparison = syllablesA[index].compareTo(syllablesB[index]);
     if (comparison != 0) {
       // -1 or +1 means that the letters are different, thus an order is found
       return comparison;

--- a/lib/src/glossary/widgets/vocabulary_list.dart
+++ b/lib/src/glossary/widgets/vocabulary_list.dart
@@ -7,7 +7,7 @@ class VocabularyList extends StatefulWidget {
   final List<Vocabulary> items;
 
   /// Function to execute when a [GlossaryListTile] is pressed
-  final Function(Vocabulary kanji)? onPressed;
+  final Function(Vocabulary vocabulary)? onPressed;
 
   const VocabularyList({required this.items, super.key, this.onPressed});
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.28.1+1
+version: 0.29.0+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/test/src/core/utils/kana_utils_test.dart
+++ b/test/src/core/utils/kana_utils_test.dart
@@ -1,0 +1,94 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:kana_to_kanji/src/core/utils/kana_utils.dart";
+
+class SplitBySyllableTestCase {
+  final String name;
+  final String input;
+  final List<int> expectedResult;
+
+  SplitBySyllableTestCase(this.name, this.input, this.expectedResult);
+}
+
+class SortBySyllableTestCase {
+  final String name;
+  final List<int> syllablesA;
+  final List<int> syllablesB;
+  final int expectedResult;
+
+  SortBySyllableTestCase(
+      this.name, this.syllablesA, this.syllablesB, this.expectedResult);
+}
+
+void main() {
+  group("splitBySyllable", () {
+    final List<SplitBySyllableTestCase> cases = [
+      SplitBySyllableTestCase("One hiragana", "あ", [0]),
+      SplitBySyllableTestCase("One katakana", "ア", [1]),
+      SplitBySyllableTestCase("One hiragana & katakana", "あア", [0, 1]),
+      SplitBySyllableTestCase("Word with a `ー`", "あー", [0, 0]),
+      SplitBySyllableTestCase("Word with a `っ`", "がっこう", [11, 38, 38, 4]),
+      SplitBySyllableTestCase("Hiragana combination", "きょ", [14, 195]),
+      SplitBySyllableTestCase("Katakana combination", "キョ", [22, 197]),
+    ];
+    for (final SplitBySyllableTestCase testCase in cases) {
+      test(testCase.name, () {
+        final List<int> result = splitBySyllable(testCase.input);
+
+        expect(testCase.expectedResult, result);
+      });
+    }
+  });
+
+  group("sortBySyllables", () {
+    final List<SortBySyllableTestCase> cases = [
+      SortBySyllableTestCase(
+          "あ - ア", [jpOrder.indexOf("あ")], [jpOrder.indexOf("ア")], -1),
+      SortBySyllableTestCase(
+          "ア - あ", [jpOrder.indexOf("ア")], [jpOrder.indexOf("あ")], 1),
+      SortBySyllableTestCase(
+          "あ - あ", [jpOrder.indexOf("あ")], [jpOrder.indexOf("あ")], 0),
+      SortBySyllableTestCase(
+          "ア - ア", [jpOrder.indexOf("ア")], [jpOrder.indexOf("ア")], 0),
+      SortBySyllableTestCase(
+          "ああ - あア",
+          [jpOrder.indexOf("あ"), jpOrder.indexOf("あ")],
+          [jpOrder.indexOf("あ"), jpOrder.indexOf("ア")],
+          -1),
+      SortBySyllableTestCase(
+          "あア - ああ",
+          [jpOrder.indexOf("あ"), jpOrder.indexOf("ア")],
+          [jpOrder.indexOf("あ"), jpOrder.indexOf("あ")],
+          1),
+      SortBySyllableTestCase(
+          "あああ - ああ",
+          [jpOrder.indexOf("あ"), jpOrder.indexOf("あ"), jpOrder.indexOf("あ")],
+          [jpOrder.indexOf("あ"), jpOrder.indexOf("あ")],
+          1),
+      SortBySyllableTestCase(
+          "がここきょ - がここキキ",
+          [
+            jpOrder.indexOf("が"),
+            jpOrder.indexOf("こ"),
+            jpOrder.indexOf("こ"),
+            jpOrder.indexOf("き"),
+            jpOrder.indexOf("ょ")
+          ],
+          [
+            jpOrder.indexOf("が"),
+            jpOrder.indexOf("こ"),
+            jpOrder.indexOf("こ"),
+            jpOrder.indexOf("キ"),
+            jpOrder.indexOf("キ")
+          ],
+          -1),
+    ];
+    for (final SortBySyllableTestCase testCase in cases) {
+      test(testCase.name, () {
+        final int result =
+            sortBySyllables(testCase.syllablesA, testCase.syllablesB);
+
+        expect(testCase.expectedResult, result);
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Prerequisites
### Related PR
- https://github.com/RoadTripMoustache/kana_to_kanji/pull/252
- https://github.com/RoadTripMoustache/kana_to_kanji/pull/259

## 📖 Description
Improve sorting of kanji & vocabulary with the japanese order.

### ⁉️ Related Issues
closes : #128 

### 🧪 How to test the change?
- Open the application
- Go to the Glossary
- Go to the Vocabulary tab
- Change the sort filter to alphabetical
- Close the sort filter menu
- Change the sort filter to japanese order
- Close the sort filter menu

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.