### PR TITLE
fix: Align icons

### DIFF
--- a/lib/src/core/widgets/chip_list.dart
+++ b/lib/src/core/widgets/chip_list.dart
@@ -46,8 +46,8 @@ class _ChipListState extends State<ChipList> {
         if (widget.children.isNotEmpty)
           TextButton.icon(
               icon: Icon(showAll
-                  ? Icons.keyboard_arrow_up
-                  : Icons.keyboard_arrow_down),
+                  ? Icons.keyboard_arrow_up_rounded
+                  : Icons.keyboard_arrow_down_rounded),
               onPressed: () {
                 setState(() {
                   showAll = !showAll;

--- a/lib/src/feedback/widgets/feedback_type_selection.dart
+++ b/lib/src/feedback/widgets/feedback_type_selection.dart
@@ -28,7 +28,7 @@ class FeedbackTypeSelection extends StatelessWidget {
             style: FilledButton.styleFrom(
                 backgroundColor: Colors.red, foregroundColor: Colors.black),
             onPressed: () => onPressed(FeedbackType.bug),
-            icon: const Icon(Icons.bug_report_outlined,
+            icon: const Icon(Icons.bug_report_rounded,
                 size: _kButtonLeadingIconSize),
             label: ListTile(
               title: Text(l10n.feedback_report_bug),
@@ -38,7 +38,7 @@ class FeedbackTypeSelection extends StatelessWidget {
       FilledButton.icon(
           key: featureRequestButtonKey,
           style: FilledButton.styleFrom(foregroundColor: Colors.white),
-          icon: const Icon(Icons.design_services_outlined,
+          icon: const Icon(Icons.design_services_rounded,
               size: _kButtonLeadingIconSize),
           onPressed: () => onPressed(FeedbackType.featureRequest),
           label: ListTile(

--- a/lib/src/glossary/widgets/filter_by.dart
+++ b/lib/src/glossary/widgets/filter_by.dart
@@ -68,7 +68,7 @@ class _FilterBy extends State<FilterBy> {
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
-          icon: const Icon(Icons.close),
+          icon: const Icon(Icons.close_rounded),
           onPressed: () {
             Navigator.of(context).pop();
             widget.filterGlossary();
@@ -77,7 +77,7 @@ class _FilterBy extends State<FilterBy> {
         title: Text(l10n.glossary_filter_by_title),
         actions: [
           IconButton(
-            icon: const Icon(Icons.clear_all),
+            icon: const Icon(Icons.clear_all_rounded),
             onPressed: _clearLists,
           )
         ],

--- a/lib/src/glossary/widgets/search_bar.dart
+++ b/lib/src/glossary/widgets/search_bar.dart
@@ -250,7 +250,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                     onPressed: () async {
                       await Navigator.of(context).push(_createRouteFilterBy());
                     },
-                    icon: const Icon(Icons.tune),
+                    icon: const Icon(Icons.tune_rounded),
                   ),
                 ],
               )),
@@ -269,7 +269,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
             child: const SizedBox(
               width: 36,
               height: kToolbarHeight,
-              child: Icon(Icons.arrow_back),
+              child: Icon(Icons.arrow_back_rounded),
             ),
           ),
         AnimatedPositioned(
@@ -323,7 +323,7 @@ class _GlossarySearchBarState extends State<GlossarySearchBarContent> {
                               child: const SizedBox(
                                 width: kToolbarHeight,
                                 height: kToolbarHeight,
-                                child: Icon(Icons.search),
+                                child: Icon(Icons.search_rounded),
                               ),
                             )
                           : null,

--- a/lib/src/glossary/widgets/sort_by.dart
+++ b/lib/src/glossary/widgets/sort_by.dart
@@ -32,7 +32,7 @@ class _SortBy extends State<SortBy> {
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
-          icon: const Icon(Icons.close),
+          icon: const Icon(Icons.close_rounded),
           onPressed: () {
             Navigator.of(context).pop();
             widget.sortGlossary(_selectedOrder);

--- a/lib/src/quiz/conclusion/quiz_conclusion_view.dart
+++ b/lib/src/quiz/conclusion/quiz_conclusion_view.dart
@@ -34,7 +34,7 @@ class QuizConclusionView extends StatelessWidget {
                 surfaceTintColor: Colors.transparent,
                 backgroundColor: Colors.transparent,
                 leading: IconButton(
-                  icon: const Icon(Icons.close),
+                  icon: const Icon(Icons.close_rounded),
                   onPressed: () => context.pop(),
                 ),
                 title: Text(l10n.quiz_conclusion)),

--- a/lib/src/quiz/prepare/prepare_quiz_view.dart
+++ b/lib/src/quiz/prepare/prepare_quiz_view.dart
@@ -29,10 +29,10 @@ class PrepareQuizView extends StatelessWidget {
               if (viewModel.selectedGroups.isNotEmpty)
                 IconButton(
                     onPressed: viewModel.resetSelected,
-                    icon: const Icon(Icons.clear_all)),
+                    icon: const Icon(Icons.clear_all_rounded)),
               IconButton(
                   onPressed: viewModel.onSettingsTapped,
-                  icon: const Icon(Icons.settings_outlined))
+                  icon: const Icon(Icons.settings_rounded))
             ],
           ),
           body: SingleChildScrollView(

--- a/lib/src/quiz/quiz_view.dart
+++ b/lib/src/quiz/quiz_view.dart
@@ -29,7 +29,7 @@ class QuizView extends StatelessWidget {
               centerTitle: true,
               backgroundColor: Colors.transparent,
               leading: IconButton(
-                icon: const Icon(Icons.close),
+                icon: const Icon(Icons.close_rounded),
                 onPressed: () => context.pop(),
               ),
               title: Row(

--- a/lib/src/quiz/widgets/question_tile.dart
+++ b/lib/src/quiz/widgets/question_tile.dart
@@ -126,7 +126,7 @@ class _QuestionTileState extends State<QuestionTile> {
                             borderSide: BorderSide(color: Colors.green))
                         : null,
                     suffixIcon: _showSuccess
-                        ? const Icon(Icons.check, color: Colors.green)
+                        ? const Icon(Icons.check_rounded, color: Colors.green)
                         : null),
                 onSubmitted: onSubmit),
           ),

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -26,7 +26,7 @@ class SettingsView extends StatelessWidget {
               title: Text(l10n.settings),
               centerTitle: true,
               leading: IconButton(
-                icon: const Icon(Icons.close),
+                icon: const Icon(Icons.close_rounded),
                 onPressed: () => context.pop(),
               ),
             ),
@@ -56,7 +56,7 @@ class SettingsView extends StatelessWidget {
                       trailing: DropdownButton<Locale>(
                         value: viewModel.currentLocale ??
                             Localizations.localeOf(context),
-                        icon: const Icon(Icons.arrow_downward),
+                        icon: const Icon(Icons.arrow_downward_rounded),
                         style: const TextStyle(color: Colors.deepPurple),
                         underline: Container(
                           height: 2,
@@ -85,7 +85,7 @@ class SettingsView extends StatelessWidget {
                             context: context,
                             applicationVersion: viewModel.version);
                       },
-                      trailing: const Icon(Icons.arrow_forward),
+                      trailing: const Icon(Icons.arrow_forward_rounded),
                     ),
                   ],
                 ),

--- a/lib/src/settings/settings_view_model.dart
+++ b/lib/src/settings/settings_view_model.dart
@@ -19,15 +19,15 @@ class SettingsViewModel extends BaseViewModel {
 
   Map<ThemeMode, Map<String, dynamic>> get themeModes => {
         ThemeMode.light: {
-          "icon": Icons.light_mode_outlined,
+          "icon": Icons.light_mode_rounded,
           "tooltip": l10n.settings_theme_light
         },
         ThemeMode.system: {
-          "icon": Icons.smartphone_outlined,
+          "icon": Icons.smartphone_rounded,
           "tooltip": l10n.settings_theme_system
         },
         ThemeMode.dark: {
-          "icon": Icons.dark_mode_outlined,
+          "icon": Icons.dark_mode_rounded,
           "tooltip": l10n.settings_theme_dark
         },
       };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1067,5 +1067,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.27.0+1
+version: 0.27.1+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.28.0+1
+version: 0.28.1+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/test/src/feedback/widgets/feedback_type_selection_test.dart
+++ b/test/src/feedback/widgets/feedback_type_selection_test.dart
@@ -31,7 +31,7 @@ void main() {
       expect(button, findsOneWidget);
       expect(
           find.descendant(
-              of: button, matching: find.byIcon(Icons.bug_report_outlined)),
+              of: button, matching: find.byIcon(Icons.bug_report_rounded)),
           findsOneWidget);
       expect(
           find.descendant(
@@ -50,8 +50,7 @@ void main() {
       expect(button, findsOneWidget);
       expect(
           find.descendant(
-              of: button,
-              matching: find.byIcon(Icons.design_services_outlined)),
+              of: button, matching: find.byIcon(Icons.design_services_rounded)),
           findsOneWidget);
       expect(
           find.descendant(

--- a/test/src/settings/widgets/tile_item_test.dart
+++ b/test/src/settings/widgets/tile_item_test.dart
@@ -9,7 +9,7 @@ void main() {
     testWidgets("UI", (WidgetTester tester) async {
       const String title = "title";
       const String subtitle = "Subtitle";
-      const IconData leading = Icons.abc;
+      const IconData leading = Icons.abc_rounded;
       const IconData trailing = Icons.account_circle_outlined;
 
       await tester.pumpLocalizedWidget(const TileItem(


### PR DESCRIPTION
## Prerequisites
### Related PR
- https://github.com/RoadTripMoustache/kana_to_kanji/pull/259

## 📖 Description
Align icons to have rounded icons everywhere except in the bottom nav bar.

### ⁉️ Related Issues
closes: #209 

### 🧪 How to test the change?
- Open the application
- Go to the settings
- Go to the glossary
- Open filter tab
- Close filter tab
- Open Sort tab
- Close sort tab
- Do a search
- Go to the practice tab
- Create a quiz
- Finish the quiz

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.