### PR TITLE
feat: Practice tab home skeleton

### DIFF
--- a/lib/src/core/widgets/app_bottom_navigation_bar.dart
+++ b/lib/src/core/widgets/app_bottom_navigation_bar.dart
@@ -2,7 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_gen/gen_l10n/app_localizations.dart";
 import "package:go_router/go_router.dart";
 import "package:kana_to_kanji/src/core/models/app_navigation_destination.dart";
-import "package:kana_to_kanji/src/quiz/prepare/prepare_quiz_view.dart";
+import "package:kana_to_kanji/src/practice/quiz/practice_view.dart";
 
 class AppBottomNavigationBar extends StatelessWidget {
   const AppBottomNavigationBar({super.key});
@@ -40,7 +40,7 @@ class AppBottomNavigationBar extends StatelessWidget {
             icon: const Icon(Icons.psychology_outlined),
             selectedIcon: const Icon(Icons.psychology_rounded),
             label: l10n.app_bottom_bar_practice,
-            location: PrepareQuizView.routeName),
+            location: PracticeView.routeName),
         AppNavigationDestination(
             icon: const Icon(Icons.menu_book_outlined),
             selectedIcon: const Icon(Icons.menu_book_rounded),

--- a/lib/src/practice/quiz/practice_view.dart
+++ b/lib/src/practice/quiz/practice_view.dart
@@ -1,0 +1,32 @@
+import "package:flutter/material.dart";
+import "package:flutter_gen/gen_l10n/app_localizations.dart";
+import "package:go_router/go_router.dart";
+import "package:kana_to_kanji/src/core/widgets/app_scaffold.dart";
+import "package:kana_to_kanji/src/practice/quiz/practice_view_model.dart";
+import "package:stacked/stacked.dart";
+
+class PracticeView extends StatelessWidget {
+  static const routeName = "/practice";
+
+  const PracticeView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return ViewModelBuilder<PracticeViewModel>.reactive(
+      viewModelBuilder: () => PracticeViewModel(GoRouter.of(context)),
+      builder: (context, viewModel, child) => AppScaffold(
+        resizeToAvoidBottomInset: true,
+        showBottomBar: true,
+        body: SizedBox(
+          width: double.infinity,
+          child: FilledButton(
+            onPressed: () {},
+            child: Text(l10n.practice_quiz_practice_button),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/practice/quiz/practice_view_model.dart
+++ b/lib/src/practice/quiz/practice_view_model.dart
@@ -1,0 +1,11 @@
+import "package:go_router/go_router.dart";
+import "package:stacked/stacked.dart";
+
+class PracticeViewModel extends FutureViewModel {
+  final GoRouter router;
+
+  PracticeViewModel(this.router);
+
+  @override
+  Future futureToRun() async {}
+}

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -3,6 +3,7 @@ import "package:go_router/go_router.dart";
 import "package:kana_to_kanji/src/core/models/group.dart";
 import "package:kana_to_kanji/src/core/widgets/app_not_found_view.dart";
 import "package:kana_to_kanji/src/glossary/glossary_view.dart";
+import "package:kana_to_kanji/src/practice/quiz/practice_view.dart";
 import "package:kana_to_kanji/src/quiz/conclusion/quiz_conclusion_view.dart";
 import "package:kana_to_kanji/src/quiz/models/question.dart";
 import "package:kana_to_kanji/src/quiz/prepare/prepare_quiz_view.dart";
@@ -56,5 +57,8 @@ GoRouter buildRouter([GlobalKey<NavigatorState>? key]) => GoRouter(
               builder: (_, __) => const SettingsView()),
           GoRoute(
               path: GlossaryView.routeName,
-              builder: (_, __) => const GlossaryView())
+              builder: (_, __) => const GlossaryView()),
+          GoRoute(
+              path: PracticeView.routeName,
+              builder: (_, __) => const PracticeView())
         ]);

--- a/localization/en.arb
+++ b/localization/en.arb
@@ -309,5 +309,6 @@
   "glossary_sort_by_alphabetical": "Alphabetical (A-Z)",
   "glossary_sort_by_japanese": "Japanese syllable (あ-お)",
   "snackbar_update_version_action": "Update",
-  "snackbar_update_version_message": "A new version is available!"
+  "snackbar_update_version_message": "A new version is available!",
+  "practice_quiz_practice_button": "Practice"
 }

--- a/localization/fr.arb
+++ b/localization/fr.arb
@@ -304,5 +304,6 @@
   "glossary_sort_by_alphabetical": "Alphabétique (A-Z)",
   "glossary_sort_by_japanese": "Syllabe japonaise (あ-お)",
   "snackbar_update_version_action": "Mettre à jour",
-  "snackbar_update_version_message": "Une nouvelle version est disponible !"
+  "snackbar_update_version_message": "Une nouvelle version est disponible !",
+  "practice_quiz_practice_button": "Pratique"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 0.31.0+1
+version: 0.32.0+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'


### PR DESCRIPTION
## Prerequisites
### Related PR
- https://github.com/RoadTripMoustache/kana_to_kanji/pull/259
- https://github.com/RoadTripMoustache/kana_to_kanji/pull/257

## 📖 Description
Add practice skeleton page.

### ⁉️ Related Issues
closes: #162 

### 🖼️ Screenshots:

<details>
    <summary>The skeleton page</summary> 

![image](https://github.com/RoadTripMoustache/kana_to_kanji/assets/36586573/548762c0-379e-4b1c-8787-df15fffe08bd)

</details>

### 🧪 How to test the change?
- Open the application
- Click on the "Practice" tab

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added/updated tests.
- [x] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.