### PR TITLE
feat(glossary): add no result widget for Kanji and vocabulary

### DIFF
--- a/lib/src/glossary/widgets/kanji_list.dart
+++ b/lib/src/glossary/widgets/kanji_list.dart
@@ -1,9 +1,11 @@
 import "package:flutter/material.dart";
 import "package:flutter_rtm/flutter_rtm.dart";
 import "package:infinite_scroll_pagination/infinite_scroll_pagination.dart";
+import "package:kana_to_kanji/src/core/constants/resource_type.dart";
 import "package:kana_to_kanji/src/core/models/resources/kanji.dart";
 import "package:kana_to_kanji/src/glossary/pagination_helper.dart";
 import "package:kana_to_kanji/src/glossary/widgets/glossary_list_tile.dart";
+import "package:kana_to_kanji/src/glossary/widgets/search_no_result.dart";
 
 class KanjiList extends StatelessWidget {
   final Function(Kanji)? onPressed;
@@ -21,6 +23,8 @@ class KanjiList extends StatelessWidget {
       firstPageProgressIndicatorBuilder: (context) => const Center(),
       newPageProgressIndicatorBuilder:
           (context) => const Center(child: RTMSpinner()),
+      noItemsFoundIndicatorBuilder:
+          (context) => const SearchNoResult(type: ResourceType.kanji),
       animateTransitions: true,
       transitionDuration: const Duration(milliseconds: 400),
       itemBuilder:

--- a/lib/src/glossary/widgets/search_no_result.dart
+++ b/lib/src/glossary/widgets/search_no_result.dart
@@ -1,0 +1,27 @@
+import "package:flutter/material.dart";
+import "package:kana_to_kanji/l10n/app_localizations.dart";
+import "package:kana_to_kanji/src/core/constants/resource_type.dart";
+
+class SearchNoResult extends StatelessWidget {
+  final ResourceType type;
+
+  const SearchNoResult({required this.type, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context);
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    final TextStyle? titleStyle = textTheme.titleLarge;
+
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        spacing: 16,
+        children: [
+          Text(l10n.glossary_not_found(type.name), style: titleStyle),
+          Text(l10n.glossary_not_found_subtitle, style: textTheme.bodyMedium),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/glossary/widgets/vocabulary_list.dart
+++ b/lib/src/glossary/widgets/vocabulary_list.dart
@@ -1,9 +1,11 @@
 import "package:flutter/material.dart";
 import "package:flutter_rtm/flutter_rtm.dart";
 import "package:infinite_scroll_pagination/infinite_scroll_pagination.dart";
+import "package:kana_to_kanji/src/core/constants/resource_type.dart";
 import "package:kana_to_kanji/src/core/models/resources/vocabulary.dart";
 import "package:kana_to_kanji/src/glossary/pagination_helper.dart";
 import "package:kana_to_kanji/src/glossary/widgets/glossary_list_tile.dart";
+import "package:kana_to_kanji/src/glossary/widgets/search_no_result.dart";
 
 class VocabularyList extends StatelessWidget {
   final Function(Vocabulary)? onPressed;
@@ -21,6 +23,8 @@ class VocabularyList extends StatelessWidget {
       firstPageProgressIndicatorBuilder: (context) => const Center(),
       newPageProgressIndicatorBuilder:
           (context) => const Center(child: RTMSpinner()),
+      noItemsFoundIndicatorBuilder:
+          (context) => const SearchNoResult(type: ResourceType.vocabulary),
       animateTransitions: true,
       transitionDuration: const Duration(milliseconds: 400),
       itemBuilder:

--- a/localization/en.arb
+++ b/localization/en.arb
@@ -245,6 +245,16 @@
   "glossary_filter_by_title": "Filter by",
   "glossary_filter_by_apply": "Apply",
   "glossary_filter_by_clear": "Reset all",
+  "glossary_not_found": "No {resource, select, kanji{kanji} vocabulary{vocabulary} other{}} found",
+  "@glossary_not_found": {
+    "placeholders": {
+      "resource": {
+        "type": "String",
+        "description": "Resource type that was searched for"
+      }
+    }
+  },
+  "glossary_not_found_subtitle": "Try to search a synonym or a different spelling",
   "glossary_tile_meanings": "{count, plural, zero{{meaning}} other{{meaning} + {count} other}}}",
   "@glossary_tile_meanings": {
     "description": "Present the main meaning of the kanji or vocabulary and the number of other meanings",

--- a/localization/fr.arb
+++ b/localization/fr.arb
@@ -240,6 +240,16 @@
   "glossary_filter_by_title": "Filtrer par",
   "glossary_filter_by_apply": "Appliquer",
   "glossary_filter_by_clear": "Éffacer les filtres",
+  "glossary_not_found": "Aucun {resource, select, kanji{kanji} vocabulary{mot de vocabulaire} other{}} trouvé",
+  "@glossary_not_found": {
+    "placeholders": {
+      "resource": {
+        "type": "String",
+        "description": "Resource type that was searched for"
+      }
+    }
+  },
+  "glossary_not_found_subtitle": "Essayer de chercher un synonyme ou une autre écriture",
   "glossary_tile_meanings": "{count, plural, zero{{meaning}} other{{meaning} + {count} autres}}}",
   "@glossary_tile_meanings": {
     "description": "Principal traduction du kanji ou mot de vocabulaire",


### PR DESCRIPTION
## 📖 Description
<!--- Describe your changes in detail -->

Implement basic no found page for the glossary

### ⁉️ Related Issues
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- For more explanation: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--- Please link the issue here: (use keyword `closes: #12345`) -->

closes #101 

<!--- If it's a visual change, please provide a screenshot/video of the changes -->
### 🖼️ Screenshots:
<!--- Use the spoiler system for your screenshots/videos -->

| Kanji | Vocabulary |
|--------|--------|
| ![](https://github.com/user-attachments/assets/4c5de604-e617-4dc7-8c46-d663d37c0ae2) | ![](https://github.com/user-attachments/assets/e1b9f681-80bf-4f49-b3a1-9e54400c47ca) |

### 🧪 How to test the change?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your unit test, and the manual tests you did -->
<!--- see how your change affects other areas of the code, etc. -->

### ☑️ Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] I have added/updated tests.
- [ ] Make sure to add either one of the following labels: `version: Major`,`version: Minor` or `version: Patch`.